### PR TITLE
fix: remove non-existent plugins from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ cp ~/100x-templates/node-fullstack.md ./AGENTS.md       # Codex
 
 ## Plugins (Claude Code Bonus)
 
-14 curated plugins auto-installed into Claude Code:
+12 curated plugins auto-installed into Claude Code:
 
-**superpowers** | **frontend-design** | **stripe** | **hookify** | **pr-review-toolkit** | **code-review** | **playwright** | **firecrawl** | **github** | **remember** | **skill-creator** | **code-simplifier** | **security-guidance** | **brightdata**
+**superpowers** | **frontend-design** | **stripe** | **hookify** | **pr-review-toolkit** | **code-review** | **playwright** | **firecrawl** | **github** | **skill-creator** | **code-simplifier** | **security-guidance**
 
 Only installed when you select Claude Code + Plugins during setup.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,7 +59,7 @@ cd ~/100x-dev && ./install.sh
 - 15 workflow files are copied to `~/.claude/commands/`
 - 7 db-engine files are copied to `~/.claude/commands/db-engines/`
 - Each file gets `$ARGUMENTS` appended (Claude Code's argument passing mechanism)
-- 14 plugins are merged into `~/.claude/settings.json`
+- 12 plugins are merged into `~/.claude/settings.json`
 
 **After install:**
 1. Restart Claude Code (or start a new session)

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -4,7 +4,6 @@
     "superpowers@claude-plugins-official",
     "playwright@claude-plugins-official",
     "code-review@claude-plugins-official",
-    "remember@claude-plugins-official",
     "firecrawl@claude-plugins-official",
     "github@claude-plugins-official",
     "security-guidance@claude-code-plugins",
@@ -12,8 +11,7 @@
     "code-simplifier@claude-plugins-official",
     "pr-review-toolkit@claude-plugins-official",
     "hookify@claude-plugins-official",
-    "stripe@claude-plugins-official",
-    "brightdata-plugin@claude-plugins-official"
+    "stripe@claude-plugins-official"
   ],
   "extraKnownMarketplaces": {
     "claude-code-plugins": {


### PR DESCRIPTION
## Summary

- Remove `remember@claude-plugins-official` and `brightdata-plugin@claude-plugins-official` from `plugins/plugins.json` — these don't exist in the marketplace
- Update plugin count from 14 to 12 in `README.md` and `docs/USAGE.md`

## Problem

Running `install.sh` with plugins adds these non-existent entries to `~/.claude/settings.json`, causing persistent `2 errors during load` warnings on every Claude Code session.

## Test plan

- [ ] Run `./install.sh` with Claude Code + Plugins selected — verify no install errors
- [ ] Run `/reload-plugins` in Claude Code — verify 0 errors
- [ ] Verify `plugins/plugins.json` has 12 entries
- [ ] Verify README and USAGE.md both say "12 curated plugins"

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)