### PR TITLE
fix(update): correct plugins.json path in updater script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -86,7 +86,7 @@ echo -e "  ${GREEN}→ Updated $count workflows ✓${NC}"
 python3 << PYEOF
 import json, os
 
-plugins_file = os.path.join('$REPO_DIR', 'plugins.json')
+plugins_file = os.path.join('$REPO_DIR', 'plugins', 'plugins.json')
 settings_file = '$SETTINGS_FILE'
 
 with open(plugins_file) as f:


### PR DESCRIPTION
## Summary
- Fix `FileNotFoundError` in `update.sh` when syncing plugin registry
- The updater referenced `plugins.json` at repo root, but the file lives at `plugins/plugins.json`
- All users running the updater hit this error on the plugin sync step

## Changes
- `update.sh:89` — corrected path from `$REPO_DIR/plugins.json` to `$REPO_DIR/plugins/plugins.json`

## Test plan
- [ ] Run `bash update.sh` and verify no `FileNotFoundError`
- [ ] Verify plugin registry sync completes successfully

## Impact
Anyone who installed 100x-dev and runs the updater will hit this bug. Fix ensures smooth updates for all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)