### PR TITLE
fix: 100x-dev command not found after curl-based install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ```bash
 # Mac / Linux
 curl -fsSL https://raw.githubusercontent.com/rajitsaha/100x-dev/main/get.sh | bash
+source ~/.zshrc   # or ~/.bashrc — reload shell to activate the 100x-dev command
 
 # Windows (or anywhere Node.js is installed)
 npm install -g 100x-dev && 100x-dev install
@@ -34,7 +35,7 @@ Run once per machine. Then set up each project you work on:
 
 ```bash
 cd /path/to/your/project
-100x-dev init
+100x-dev init        # run in your terminal, not inside Claude Code
 ```
 
 > **New here?** See the [full usage guide](docs/USAGE.md).
@@ -107,7 +108,7 @@ The installer asks which tools you use and sets up each one. For Claude Code it 
 - **10 Claude Code plugins** — superpowers, frontend-design, playwright, github, pr-review-toolkit, hookify, skill-creator, code-simplifier, security-guidance, claude-mem
 - **4 project templates** — node-fullstack, node-frontend, python-api, docker-compose
 - **2 GitHub Actions templates** — CI pipeline (lint + real-DB tests + E2E) and release pipeline
-- **Shell aliases** — `cc`, `ccc`, `100x-update`, `100x-check`
+- **Shell aliases** — `100x-dev`, `cc`, `ccc`, `100x-update`, `100x-check`
 
 ---
 
@@ -118,6 +119,8 @@ The installer asks which tools you use and sets up each one. For Claude Code it 
 **Auto-banner**: Claude Code shows an update notice at session start when a new version is available.
 
 **Manual**: `100x-dev update` to update, `100x-dev check` to check.
+
+> **Note:** `100x-dev` commands run in your **terminal** (zsh/bash). Claude Code slash commands like `/commit` and `/reload-plugins` run **inside Claude Code**. They are different environments.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,6 +18,7 @@
 **Mac / Linux** — run once per machine:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rajitsaha/100x-dev/main/get.sh | bash
+source ~/.zshrc   # or ~/.bashrc — reload shell to activate the 100x-dev command
 ```
 
 **Windows** (or anywhere Node.js is installed):
@@ -26,6 +27,8 @@ npm install -g 100x-dev && 100x-dev install
 ```
 
 The installer sets up Claude Code globally (`~/.claude/commands/`) and scaffolds a `CLAUDE.md` in your project with placeholders for DB config, GCP, production URLs, and security exceptions.
+
+> **Terminal vs Claude Code:** The `100x-dev` command and its subcommands (`init`, `update`, `check`) run in your **terminal** (zsh/bash). Slash commands like `/commit`, `/gate`, and `/reload-plugins` run **inside Claude Code**. Don't mix them up — if you see "command not found", you're likely in the wrong environment.
 
 ### Add to a project
 
@@ -145,8 +148,9 @@ Add to your team's onboarding checklist:
 ```
 - [ ] Mac/Linux: curl -fsSL https://raw.githubusercontent.com/rajitsaha/100x-dev/main/get.sh | bash
       Windows:   npm install -g 100x-dev && 100x-dev install
+- [ ] Reload shell: source ~/.zshrc (or ~/.bashrc)
 - [ ] cd <your-project> && 100x-dev init
-- [ ] Verify: open a project and run /gate
+- [ ] Open Claude Code in your project and run /gate
 ```
 
 For teams using Cursor/Codex/etc., commit the generated instruction file to each repo — new team members get the workflows automatically on clone.

--- a/install.sh
+++ b/install.sh
@@ -203,6 +203,16 @@ echo "────────────────────────�
 echo ""
 echo "──────────────────────────────────────"
 echo -e "${GREEN}✓ Done!${NC}"
-[ "$TOOL_CLAUDE" = true ] && echo -e "${CYAN}  Claude Code: restart to load workflows. Run /reload-plugins for plugins.${NC}"
-echo -e "${CYAN}  Next: cd into a project and run  100x-dev init  to set it up.${NC}"
+echo ""
+if [ "$TOOL_CLAUDE" = true ]; then
+  echo -e "  ${CYAN}In Claude Code:${NC}"
+  echo -e "    Restart Claude Code to load workflows."
+  echo -e "    Run ${YELLOW}/reload-plugins${NC} inside Claude Code to load plugins."
+  echo ""
+fi
+echo -e "  ${CYAN}In your terminal:${NC}"
+if [ -n "$RC_FILE" ]; then
+  echo -e "    source ~/${RC_FILE##*/}          # reload shell aliases"
+fi
+echo -e "    cd your-project && ${YELLOW}100x-dev init${NC}  # set up a project"
 echo ""

--- a/shell/aliases.sh
+++ b/shell/aliases.sh
@@ -9,6 +9,8 @@ alias ccc='claude --continue'
 
 # Setup management
 # shellcheck disable=SC2139
+alias 100x-dev="node $HOME/100x-dev/bin/100x-dev.js"
+# shellcheck disable=SC2139
 alias 100x-update="$HOME/100x-dev/update.sh"
 # shellcheck disable=SC2139
 alias 100x-check="$HOME/100x-dev/update.sh --check-only"


### PR DESCRIPTION
## Summary

- **Add `100x-dev` alias** in `shell/aliases.sh` so the command works after `curl | bash` install (not just npm global install)
- **Clarify post-install output** in `install.sh` — separate "In Claude Code" vs "In your terminal" sections to avoid mixing slash commands (`/reload-plugins`) with shell commands (`100x-dev init`)
- **Add shell reload reminder** so users know to `source ~/.zshrc` before the alias is available

## Problem

After installing via `curl -fsSL https://raw.githubusercontent.com/rajitsaha/100x-dev/main/get.sh | bash`:

1. The installer tells users to run `100x-dev init` but the command doesn't exist in PATH — only the npm global install registers the bin entry
2. The output mixes Claude Code slash commands (`/reload-plugins`) with terminal commands (`100x-dev init`) on adjacent lines, making it unclear where each should be run

## Before / After

**Before:**
```
✓ Done!
  Claude Code: restart to load workflows. Run /reload-plugins for plugins.
  Next: cd into a project and run  100x-dev init  to set it up.
```

**After:**
```
✓ Done!

  In Claude Code:
    Restart Claude Code to load workflows.
    Run /reload-plugins inside Claude Code to load plugins.

  In your terminal:
    source ~/.zshrc          # reload shell aliases
    cd your-project && 100x-dev init  # set up a project
```

## Test plan

- [ ] Fresh `curl | bash` install → verify `100x-dev init` works after `source ~/.zshrc`
- [ ] Verify `100x-dev update` and `100x-dev check` still work
- [ ] Verify post-install output shows correct sections
- [ ] Skip shell install during setup → verify no `source` line shown in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)