### PR TITLE
harden: bash strict mode, env-var Python paths, SHA-pinned actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           name: "v${{ steps.version.outputs.version }}"
           body: |

--- a/adapters/claude-code.sh
+++ b/adapters/claude-code.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOWS_DIR="$REPO_DIR/workflows"
@@ -155,32 +155,24 @@ install_plugins() {
 
   PLUGINS_FILE="$REPO_DIR/plugins/plugins.json"
 
-  new_plugins=$(python3 -c "
-import json
-with open('$PLUGINS_FILE') as f:
-    data = json.load(f)
-print(json.dumps(data.get('plugins', [])))
-")
-
-  extra_marketplaces=$(python3 -c "
-import json
-with open('$PLUGINS_FILE') as f:
-    data = json.load(f)
-print(json.dumps(data.get('extraKnownMarketplaces', {})))
-")
-
   if [ ! -f "$SETTINGS_FILE" ]; then
     echo '{}' > "$SETTINGS_FILE"
   fi
 
-  python3 << PYEOF
-import json
+  PLUGINS_FILE="$PLUGINS_FILE" SETTINGS_FILE="$SETTINGS_FILE" python3 - <<'PYEOF'
+import json, os
 
-with open('$SETTINGS_FILE', 'r') as f:
+plugins_file = os.environ['PLUGINS_FILE']
+settings_file = os.environ['SETTINGS_FILE']
+
+with open(plugins_file) as f:
+    plugins_data = json.load(f)
+
+with open(settings_file) as f:
     settings = json.load(f)
 
-new_plugins = $new_plugins
-extra_marketplaces = $extra_marketplaces
+new_plugins = plugins_data.get('plugins', [])
+extra_marketplaces = plugins_data.get('extraKnownMarketplaces', {})
 
 enabled = settings.get('enabledPlugins', {})
 added = 0
@@ -195,7 +187,7 @@ existing_marketplaces = settings.get('extraKnownMarketplaces', {})
 existing_marketplaces.update(extra_marketplaces)
 settings['extraKnownMarketplaces'] = existing_marketplaces
 
-with open('$SETTINGS_FILE', 'w') as f:
+with open(settings_file, 'w') as f:
     json.dump(settings, f, indent=2)
 
 print(f'  Added {added} new plugins ({len(enabled)} total)')

--- a/github-actions/ci.yml
+++ b/github-actions/ci.yml
@@ -25,11 +25,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node 22
         if: hashFiles('package.json') != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22"
           cache: npm
@@ -48,7 +48,7 @@ jobs:
 
       - name: Set up Python 3.12
         if: hashFiles('pyproject.toml', 'setup.py') != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -87,11 +87,11 @@ jobs:
           --health-retries 3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node 22
         if: hashFiles('package.json') != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22"
           cache: npm
@@ -121,7 +121,7 @@ jobs:
 
       - name: Set up Python 3.12
         if: hashFiles('pyproject.toml', 'setup.py') != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
           cache: pip
@@ -166,10 +166,10 @@ jobs:
       ) != ''
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22"
           cache: npm
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: playwright-traces
           path: test-results/

--- a/install-project.sh
+++ b/install-project.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_PATH="$(cd "${1:-$PWD}" && pwd)"

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATES_DIR="$HOME/100x-templates"
 VERSION="$(cat "$REPO_DIR/VERSION" 2>/dev/null | tr -d '[:space:]')"
+RC_FILE=""
 
 # Colors
 GREEN='\033[0;32m'
@@ -95,10 +96,10 @@ _install_session_hook() {
   local settings_file="$HOME/.claude/settings.json"
   [[ -f "$settings_file" ]] || return 0
 
-python3 << PYEOF
+  SETTINGS_FILE="$settings_file" python3 - <<'PYEOF'
 import json, os
 
-settings_file = os.path.expanduser('$settings_file')
+settings_file = os.environ['SETTINGS_FILE']
 hook_cmd = os.path.expanduser('~/100x-dev/shell/check-update.sh') + ' --claude-hook'
 
 with open(settings_file) as f:

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
@@ -13,7 +13,7 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-[ "$1" = "--check-only" ] && CHECK_ONLY=true
+[ "${1:-}" = "--check-only" ] && CHECK_ONLY=true
 
 echo ""
 echo "Checking for updates..."
@@ -62,6 +62,17 @@ echo ""
 git pull origin main --quiet
 echo -e "  ${GREEN}→ Pulled latest ✓${NC}"
 
+# Optional: verify GPG signature on HEAD when HUNDRED_X_VERIFY_SIGNATURES=1.
+# Requires the maintainer's public key to be imported in the user's GPG keyring.
+if [ "${HUNDRED_X_VERIFY_SIGNATURES:-0}" = "1" ]; then
+  if git verify-commit HEAD >/dev/null 2>&1; then
+    echo -e "  ${GREEN}→ HEAD signature verified ✓${NC}"
+  else
+    echo -e "  ${YELLOW}⚠ HEAD commit is not signed or signature is invalid.${NC}"
+    echo -e "  ${YELLOW}  Set HUNDRED_X_VERIFY_SIGNATURES=0 to skip this check.${NC}"
+  fi
+fi
+
 if [ -d "$WORKFLOWS_DIR" ] && [ "$(ls -A "$WORKFLOWS_DIR" 2>/dev/null)" ]; then
   BACKUP="$CLAUDE_DIR/commands.bak.$(date +%Y%m%d_%H%M%S)"
   cp -r "$WORKFLOWS_DIR" "$BACKUP"
@@ -83,11 +94,11 @@ fi
 
 echo -e "  ${GREEN}→ Updated $count workflows ✓${NC}"
 
-python3 << PYEOF
+REPO_DIR="$REPO_DIR" SETTINGS_FILE="$SETTINGS_FILE" python3 - <<'PYEOF'
 import json, os
 
-plugins_file = os.path.join('$REPO_DIR', 'plugins', 'plugins.json')
-settings_file = '$SETTINGS_FILE'
+plugins_file = os.path.join(os.environ['REPO_DIR'], 'plugins', 'plugins.json')
+settings_file = os.environ['SETTINGS_FILE']
 
 with open(plugins_file) as f:
     repo_data = json.load(f)


### PR DESCRIPTION
## Summary

Security hardening for install/update scripts and CI workflows. No behavior changes for end users; eliminates a few low-severity issues surfaced by an audit.

- **Bash strict mode** — switch `install.sh`, `update.sh`, `install-project.sh`, `adapters/claude-code.sh` from `set -e` to `set -euo pipefail`, matching `shell/check-update.sh`. Adds `${1:-}` guard in `update.sh` and initializes `RC_FILE=""` in `install.sh` so unset-variable mode doesn't trip.
- **No more shell→Python string interpolation** — paths (`SETTINGS_FILE`, `REPO_DIR`, `PLUGINS_FILE`) are now passed via env vars and read with `os.environ[...]` inside `<<'PYEOF'` heredocs. Removes the edge case where a path containing `'` would have broken or injected into Python.
- **Opt-in signature verification** in `update.sh` — when `HUNDRED_X_VERIFY_SIGNATURES=1` is set, runs `git verify-commit HEAD` after pull and warns if unsigned. Default behavior unchanged.
- **SHA-pinned GitHub Actions** — `.github/workflows/release.yml` and `github-actions/ci.yml` pin `actions/checkout`, `softprops/action-gh-release`, `actions/setup-node`, `actions/setup-python`, `actions/upload-artifact` to commit SHAs (with version comments) per [GitHub's supply-chain guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Test plan

- [x] `bash -n` syntax check passes on all modified shell scripts (`install.sh`, `update.sh`, `install-project.sh`, `adapters/claude-code.sh`)
- [x] YAML parses cleanly on both workflow files
- [ ] Manual: run `bash install.sh` end-to-end on a clean machine and confirm workflows + plugins install
- [ ] Manual: run `bash update.sh` against a repo with new commits and confirm the pull + plugin merge still works
- [ ] Manual: run `HUNDRED_X_VERIFY_SIGNATURES=1 bash update.sh` against an unsigned commit and confirm the warning appears (not a hard failure)
- [ ] Trigger the release workflow on a tag and confirm SHA-pinned actions resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)