### PR TITLE
docs: add AGENTS.md contributor contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Contributor contract for AI coding agents working on this repo. Users see `README.md` and `docs/USAGE.md`; this file is for agents editing the repo itself.
+
+## What this repo is
+
+100x-dev is a **distributor**, not an app. The product is `modules/` (64 SKILL.md files with YAML frontmatter). Adapters in `adapters/` render those modules into each AI tool's native format (Claude Code skills, Cursor `.mdc`, Codex/Gemini/Windsurf/Copilot/Antigravity single-file configs). Users install via `npm i -g 100x-dev` or `get.sh`.
+
+## The golden rule
+
+**A module is the source of truth. Adapter output is generated.** Edit `modules/<slug>/SKILL.md`. Never hand-edit `~/.claude/skills/*`, `.cursor/rules/*.mdc`, or any rendered artifact in a consumer project — those are reset by the next adapter run.
+
+## Module shape
+
+Each module is one file: `modules/<slug>/SKILL.md` with frontmatter:
+
+```yaml
+---
+name: <slug>
+description: <one-line trigger guidance — used by Claude Code/Cursor for auto-activation>
+category: <docs|code|growth|...>
+tier: <on-demand|always-on>
+slash_command: /<name>   # optional — only for the 25 command-style modules
+---
+```
+
+A module must work across **all 8 adapters**. If you add tool-specific instructions, gate them inside the module body, not the frontmatter.
+
+## After editing a module
+
+Run the Claude Code adapter as a smoke test — it surfaces frontmatter errors and prints module counts:
+
+```bash
+./adapters/claude-code.sh
+```
+
+Expected output ends with `64 skills + 25 commands` (or whatever the current totals are). If the count drops unexpectedly, you broke a frontmatter parse.
+
+## Things that are easy to get wrong
+
+- **Don't add a `CLAUDE.md` to this repo.** This file (`AGENTS.md`) covers all tools. The `CLAUDE.md` template that ships to *consumer* projects lives under `templates/`, not at the root.
+- **Don't bump the version manually.** Use `/release` or follow `docs/USAGE.md` — `package.json`, `VERSION`, and the git tag must move together.
+- **Don't commit `.DS_Store` or `.playwright-mcp/`** (already in `.gitignore`, but worth knowing).
+- **Marketing assets in `assets/`** are generated from the HTML files in the same dir via Playwright. If you change the HTML, regenerate the PNG.
+
+## Where to look
+
+- `docs/USAGE.md` — user-facing usage (install, init, per-tool behavior)
+- `docs/v2-refactor.md` — why `modules/` replaced the old `workflows/` + `skills/` split
+- `adapters/lib/modules.py` — the parser; if frontmatter changes, this is the file to update


### PR DESCRIPTION
## Summary
- Adds a root `AGENTS.md` documenting the contributor contract for AI agents editing this repo (distinct from user-facing `README.md` / `docs/USAGE.md`).
- Covers the golden rule (modules are source-of-truth, adapter output is generated), frontmatter shape, the cross-adapter compatibility constraint, and the `./adapters/claude-code.sh` smoke test with expected module counts.
- Single `AGENTS.md` covers Claude Code, Codex, Cursor, Gemini, Windsurf, Copilot, and Antigravity — no need for per-tool root config files.

## Test plan
- [ ] Confirm `AGENTS.md` renders on the GitHub PR page
- [ ] Open this branch in Codex/Cursor and verify the agent picks up `AGENTS.md` as project guidance
- [ ] Spot-check that the documented `./adapters/claude-code.sh` output (`64 skills + 25 commands`) still matches current module counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)