### PR TITLE
docs: add SECURITY.md and custom install location guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ npm install -g 100x-dev && 100x-dev install
 cd your-project && 100x-dev init    # set up each project once
 ```
 
+> **Cloned to a custom path?** The default install lives at `~/100x-dev`. If you cloned elsewhere (e.g. `~/work/git_udemy/100x-dev`), update your shell + Claude Code config to match — see [Custom install location →](docs/USAGE.md#custom-install-location).
+
 [Full install guide →](docs/USAGE.md#installation)
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+Thanks for helping keep **100x-dev** and its users safe.
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security vulnerabilities.**
+
+Report privately via **[GitHub Security Advisories](https://github.com/rajitsaha/100x-dev/security/advisories/new)** (the "Report a vulnerability" button on the [Security tab](https://github.com/rajitsaha/100x-dev/security)). This keeps the report confidential until a fix is ready.
+
+When reporting, please include:
+
+- A clear description of the issue and its impact
+- Steps to reproduce (commands, config, environment)
+- Affected version(s) — `100x-dev --version` or commit SHA
+- Any proof-of-concept code or screenshots (optional but helpful)
+
+## What to Expect
+
+| Stage | Timeline |
+|---|---|
+| Acknowledgement of your report | Within **5 business days** |
+| Initial assessment + severity triage | Within **10 business days** |
+| Fix timeline | Communicated after triage — depends on severity and complexity |
+| Public advisory + CVE (if applicable) | Published once a fix ships, with credit to the reporter unless you request anonymity |
+
+This project is maintained by a solo author, so timelines are best-effort. Critical issues (RCE, supply-chain compromise, credential exposure) are prioritized over lower-severity ones.
+
+## Supported Versions
+
+Security fixes are applied to the **latest minor release** on the `main` branch. Older versions are not patched — please upgrade to receive fixes:
+
+```bash
+100x-dev update
+```
+
+## Scope
+
+**In scope:**
+
+- Code in this repository: shell scripts (`get.sh`, `install.sh`, `update.sh`, `shell/*.sh`), the Node CLI (`bin/`, `lib/`), adapters, templates, and generated artifacts
+- The published npm package [`100x-dev`](https://www.npmjs.com/package/100x-dev)
+- The install one-liner served from `raw.githubusercontent.com/rajitsaha/100x-dev/main/get.sh`
+
+**Out of scope:**
+
+- Vulnerabilities in **upstream tools** that 100x-dev integrates with (Claude Code, Cursor, Codex, Windsurf, Copilot, Gemini, Antigravity, npm, GitHub Actions). Report those to the respective vendors.
+- Vulnerabilities in **your project's** dependencies or generated CI workflows after `100x-dev init` runs — these are your project's responsibility.
+- Issues that require an attacker to already have write access to your machine, your `.env`, or your shell config.
+- Social-engineering or phishing scenarios that don't involve a flaw in this codebase.
+
+## Examples of In-Scope Issues
+
+- Command injection in shell scripts or template substitution
+- Path traversal when writing to user config (`~/.claude/`, `.cursor/rules/`, etc.)
+- Credential or secret leakage from `/connect`, `.env` handling, or generated artifacts
+- Supply-chain risks: tampered npm package, compromised `get.sh`, or unsafe `curl | bash` patterns
+- Unsafe defaults that expose user systems (overly permissive file modes, unvalidated downloads)
+
+## Coordinated Disclosure
+
+We follow standard coordinated-disclosure practice: please give us a reasonable window to ship a fix before publishing details. We'll keep you informed of progress and credit you in the advisory unless you prefer otherwise.
+
+Thank you for reporting responsibly.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,6 +48,45 @@ This writes the right instruction file for each enabled tool (`.cursorrules`, `A
 100x-dev check    # check for a newer version without applying it
 ```
 
+### Custom install location
+
+The default `get.sh` installer clones to `~/100x-dev` and writes that path into your `~/.zshrc` (or `~/.bashrc`) and `~/.claude/settings.json` (SessionStart hook for `check-update.sh`).
+
+If you cloned the repo somewhere else — e.g. `~/work/git_udemy/100x-dev` — you'll see errors on every shell login and Claude Code session start:
+
+```
+.zshrc:source: no such file or directory: /Users/<you>/100x-dev/shell/aliases.sh
+SessionStart:startup hook error
+```
+
+**Fix — point both files at your actual clone using `$HOME` (no usernames hardcoded):**
+
+1. **`~/.zshrc`** — replace the 100x-dev source block with a single configurable env var:
+   ```bash
+   # 100x Dev — point this at wherever you cloned/installed the repo
+   export DEV_100X_HOME="$HOME/work/git_udemy/100x-dev"   # adjust to your path
+   [ -f "$DEV_100X_HOME/shell/aliases.sh" ] && source "$DEV_100X_HOME/shell/aliases.sh"
+   ```
+   The `[ -f … ] &&` guard means a missing file fails silently instead of printing on every login.
+
+2. **`~/.claude/settings.json`** — update the SessionStart hook command. Claude Code runs hooks in non-interactive shells that don't source `~/.zshrc`, so use `$HOME` directly (always set by the OS) — `$DEV_100X_HOME` won't be available there:
+   ```json
+   "hooks": {
+     "SessionStart": [
+       {
+         "matcher": "",
+         "hooks": [
+           { "type": "command", "command": "$HOME/work/git_udemy/100x-dev/shell/check-update.sh --claude-hook" }
+         ]
+       }
+     ]
+   }
+   ```
+
+3. **Verify** — open a new terminal (no `source` errors) and start a new Claude Code session (no `SessionStart:startup hook error`).
+
+> Both files are per-user and never committed, so hardcoded paths there don't affect anyone else — but using `$HOME` keeps your config working if your username changes, and the env var keeps the repo path easy to update if you move the clone.
+
 ---
 
 ## Using the Workflows


### PR DESCRIPTION
## Summary

- **`SECURITY.md`** — adds a security policy with private vulnerability reporting via GitHub Security Advisories, defined scope (in/out), supported-version policy, and realistic solo-maintainer SLAs (5 business days to acknowledge, 10 to triage).
- **`docs/USAGE.md`** — adds a *Custom install location* subsection covering the failure mode users hit when they clone outside the default `~/100x-dev` path: stale `source` errors in `~/.zshrc` and `SessionStart:startup hook error` in Claude Code. Documents the `\$HOME` + `DEV_100X_HOME` env-var pattern and explains why Claude Code hooks can't see vars from `~/.zshrc`.
- **`README.md`** — adds a one-line callout in the Install section linking to the new USAGE anchor.

## Why

Solo-maintainer OSS repos benefit from a clear `SECURITY.md` (GitHub's security tab surfaces it, Dependabot/CodeQL look for it) — and the install-path guide closes a real footgun for anyone who clones the repo into a non-default location.

## Test plan

- [ ] `SECURITY.md` renders correctly on GitHub and the "Report a vulnerability" link resolves once Private Vulnerability Reporting is enabled (Settings → Security → Private vulnerability reporting)
- [ ] `docs/USAGE.md#custom-install-location` anchor resolves from the README link
- [ ] No changes to executable code, scripts, or templates — docs-only

## Follow-up (out of scope for this PR)

- Enable **Private Vulnerability Reporting** in repo Settings → Security so the GHSA link in `SECURITY.md` is live
- Optional: move `SECURITY.md` to `.github/SECURITY.md` if you prefer that convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)