### PR TITLE
fix: version + plugin drift, gate wording, and meta-consistency CI (#23)

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,0 +1,38 @@
+# 100x Dev — repo self-CI (meta / consistency).
+# Distinct from github-actions/ci.yml, which is a TEMPLATE users copy into their
+# own projects. This workflow guards THIS repo against drift before merge.
+name: Meta
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  consistency:
+    name: Consistency / drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      # ubuntu-latest ships python3; no setup-python action needed.
+      - name: Meta-check (counts, frontmatter, evals, version triple)
+        run: python3 scripts/meta-check.py
+
+  tests:
+    name: Generator tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Set up Node 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Run generator + adapter tests
+        run: node --test test/*.test.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Assert version triple (VERSION == package.json == tag)
+        env:
+          TAG: ${{ github.ref_name }}
+        run: python3 scripts/meta-check.py --tag "$TAG"
+
       - name: Extract CHANGELOG section
         id: notes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .worktrees/
 .DS_Store
 .playwright-mcp/
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [Unreleased]
+
+Correctness & drift hardening (issue #23) — no breaking changes.
+
+### Fixed
+- **`package.json`** — version bumped `2.0.1 → 2.0.4` to match `VERSION`/git tag. The npm-published version had been 3 releases stale.
+- **`plugins/plugins.json`** — added `understand-anything@understand-anything` and `ui-ux-pro-max@ui-ux-pro-max-skill` to `plugins[]` (previously only in `extraKnownMarketplaces`), so fresh installs enable all 12 plugins instead of 10.
+- **`update.sh`** — `run_plugin_updates()` now reads the plugin list from `plugins.json` (single source of truth) using the fully-qualified `name@marketplace` ids. The old hardcoded bare-name list silently failed for **every** plugin — `claude plugin update <bare-name>` errors with "not found"; only the qualified form works. Failures are now printed by name instead of bucketed as "skipped".
+- **`modules/gate/SKILL.md`, `modules/pr/SKILL.md`** — reconciled gate-count wording ("four"/"5 gates" → "all gates", noting Gates 4–5 are conditional).
+
+### Added
+- **`scripts/meta-check.py`** — repo consistency checker: parses all module frontmatter, asserts README counts (modules/slash/skills/plugins) match the repo, validates every `evals.json`, and asserts the `VERSION == package.json == tag` version triple.
+- **`.github/workflows/meta.yml`** — repo self-CI (distinct from the `github-actions/ci.yml` template): runs `meta-check.py` and the generator/adapter test suite on every PR and push to main.
+- **`.github/workflows/release.yml`** — added a pre-release version-triple guard that fails the release if `VERSION`, `package.json`, and the tag disagree.
+- **`test/meta-check.test.js`** — tests for the drift gate.
+
+---
+
 ## [2.0.4] — 2026-05-15
 
 Update UX improvement — no breaking changes.

--- a/modules/gate/SKILL.md
+++ b/modules/gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gate
-description: **MANDATORY before every commit and push.** All four gates must pass. Do NOT proceed if any gate fails — fix the issue first.
+description: **MANDATORY before every commit and push.** All gates must pass — Gates 1–3 always run; Gates 4 (Docker) and 5 (Cloud) run only when applicable. Do NOT proceed if any gate fails — fix the issue first.
 category: quality
 tier: core
 slash_command: /gate
@@ -8,7 +8,7 @@ slash_command: /gate
 
 # Gate — Pre-Commit Quality Gate
 
-**MANDATORY before every commit and push.** All four gates must pass. Do NOT proceed if any gate fails — fix the issue first.
+**MANDATORY before every commit and push.** All gates must pass — Gates 1–3 always run; Gates 4 (Docker) and 5 (Cloud) run only when applicable. Do NOT proceed if any gate fails — fix the issue first.
 
 ## Do NOT ask for permission. Do NOT skip gates. Do NOT continue past a failing gate.
 

--- a/modules/pr/SKILL.md
+++ b/modules/pr/SKILL.md
@@ -32,7 +32,7 @@ CURRENT_BRANCH=$(git branch --show-current)
 
 ## Phase 1 — Pre-flight
 
-Run the **gate** workflow. All 5 gates must pass before creating a PR.
+Run the **gate** workflow. All gates must pass before creating a PR (Gates 1–3 always; Gates 4–5 when applicable).
 
 **If any gate fails → STOP. Fix issues first. Do NOT create a PR with failing gates.**
 
@@ -193,7 +193,7 @@ Clean implementation. No issues found.
 ║ PR:       #<number> — <title>                        ║
 ║ Branch:   <branch> → <default_branch>                ║
 ║ Review:   AI review posted ✅                         ║
-║ Gate:     ✅ All 5 gates passed                       ║
+║ Gate:     ✅ All gates passed                         ║
 ╠══════════════════════════════════════════════════════╣
 ║ URL:      <pr_url>                                   ║
 ║ STATUS:   Awaiting human approval. DO NOT auto-merge. ║

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "100x-dev",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "64 cross-tool modules (workflows + skills). Quality gates on every commit. Works with Claude Code, Cursor, Codex, Windsurf, Antigravity, Copilot, Gemini.",
   "bin": {
     "100x-dev": "bin/100x-dev.js"

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -9,7 +9,9 @@
     "code-simplifier@claude-plugins-official",
     "pr-review-toolkit@claude-plugins-official",
     "hookify@claude-plugins-official",
-    "claude-mem@thedotmack"
+    "claude-mem@thedotmack",
+    "understand-anything@understand-anything",
+    "ui-ux-pro-max@ui-ux-pro-max-skill"
   ],
   "extraKnownMarketplaces": {
     "claude-code-plugins": {

--- a/scripts/meta-check.py
+++ b/scripts/meta-check.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Repo consistency / drift checker for 100x-dev.
+
+Run locally (`python3 scripts/meta-check.py`) or in CI (.github/workflows/meta.yml).
+Catches the drift classes that have bitten releases before:
+
+  1. Module frontmatter parses cleanly (delimited block + non-empty name & description).
+  2. Declared counts in README match what the repo actually contains
+     (modules / slash commands / auto-trigger skills / plugins) — every mention,
+     including the banner alt-text.
+  3. Every evals.json is valid JSON.
+  4. Version triple agrees: VERSION == package.json.version
+     (== git tag when TAG is passed via --tag or the TAG env var, e.g. in release.yml).
+
+Exit code 0 = all checks pass; 1 = at least one failure (each printed with a ✗).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MODULES_DIR = REPO / "modules"
+
+failures: list[str] = []
+notes: list[str] = []
+
+
+def fail(msg: str) -> None:
+    failures.append(msg)
+
+
+def ok(msg: str) -> None:
+    notes.append(msg)
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, str], bool]:
+    """Lenient line-based parse mirroring adapters/lib/modules.py.
+
+    Returns (fields, well_formed). well_formed is False when the leading/closing
+    `---` delimiters are missing.
+    """
+    if not text.startswith("---\n"):
+        return {}, False
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, False
+    fm: dict[str, str] = {}
+    current_key: str | None = None
+    for line in text[4:end].splitlines():
+        if not line.strip():
+            continue
+        if line.startswith(" ") and current_key:
+            fm[current_key] = (fm[current_key] + " " + line.strip()).strip()
+            continue
+        if ":" in line:
+            key, _, val = line.partition(":")
+            current_key = key.strip()
+            fm[current_key] = val.strip()
+    return fm, True
+
+
+def check_modules() -> dict[str, int]:
+    """Parse every module; fail on malformed frontmatter. Returns computed counts."""
+    skill_files = sorted(MODULES_DIR.glob("*/SKILL.md"))
+    if not skill_files:
+        fail("no modules found under modules/*/SKILL.md")
+        return {"modules": 0, "slash": 0, "skills": 0}
+
+    slash = 0
+    for sf in skill_files:
+        fm, well_formed = split_frontmatter(sf.read_text())
+        slug = sf.parent.name
+        if not well_formed:
+            fail(f"{slug}: SKILL.md has no parseable `---` frontmatter block")
+            continue
+        if not fm.get("name"):
+            fail(f"{slug}: frontmatter missing `name`")
+        if not fm.get("description"):
+            fail(f"{slug}: frontmatter missing `description`")
+        if fm.get("slash_command"):
+            slash += 1
+
+    total = len(skill_files)
+    counts = {"modules": total, "slash": slash, "skills": total - slash}
+    ok(f"modules parsed: {total} ({slash} slash commands, {total - slash} auto-trigger skills)")
+    return counts
+
+
+def check_plugins() -> int:
+    data = json.loads((REPO / "plugins" / "plugins.json").read_text())
+    n = len(data.get("plugins", []))
+    # Every enabled plugin must be a fully-qualified name@marketplace id, and its
+    # marketplace must be resolvable (built-in official marketplaces or declared
+    # in extraKnownMarketplaces). Bare names silently no-op `claude plugin update`.
+    OFFICIAL = {"claude-plugins-official", "claude-code-plugins"}
+    known = OFFICIAL | set(data.get("extraKnownMarketplaces", {}).keys())
+    for entry in data.get("plugins", []):
+        if "@" not in entry:
+            fail(f"plugins.json: '{entry}' is not a fully-qualified name@marketplace id")
+            continue
+        marketplace = entry.split("@", 1)[1]
+        if marketplace not in known:
+            fail(f"plugins.json: '{entry}' references unknown marketplace '{marketplace}'")
+    ok(f"plugins[] entries: {n}")
+    return n
+
+
+def check_readme_counts(counts: dict[str, int]) -> None:
+    """Assert every numeric count mention in the README matches the repo."""
+    readme = (REPO / "README.md").read_text()
+    # label in README -> computed key
+    patterns = {
+        r"(\d+)\s+modules": ("modules", counts["modules"]),
+        r"(\d+)\s+slash commands": ("slash commands", counts["slash"]),
+        r"(\d+)\s+auto-trigger skills": ("auto-trigger skills", counts["skills"]),
+        r"(\d+)\s+plugins": ("plugins", counts["plugins"]),
+    }
+    for pat, (label, expected) in patterns.items():
+        found = [int(m) for m in re.findall(pat, readme)]
+        if not found:
+            fail(f"README: no '{label}' count mention found (expected {expected})")
+            continue
+        bad = [v for v in found if v != expected]
+        if bad:
+            fail(f"README: '{label}' says {bad} but repo has {expected}")
+        else:
+            ok(f"README '{label}' count = {expected} ({len(found)} mention(s)) ✓")
+
+
+def check_evals() -> None:
+    eval_files = sorted(MODULES_DIR.glob("**/evals.json"))
+    bad = 0
+    for ef in eval_files:
+        try:
+            json.loads(ef.read_text())
+        except json.JSONDecodeError as e:
+            fail(f"{ef.relative_to(REPO)}: invalid JSON — {e}")
+            bad += 1
+    ok(f"evals.json validated: {len(eval_files)} file(s), {bad} invalid")
+
+
+def check_version_triple(tag: str | None) -> None:
+    version_file = (REPO / "VERSION").read_text().strip()
+    pkg_version = json.loads((REPO / "package.json").read_text())["version"]
+    if version_file != pkg_version:
+        fail(f"version drift: VERSION={version_file} != package.json={pkg_version}")
+    else:
+        ok(f"VERSION == package.json == {version_file}")
+    if tag:
+        tag_version = tag.lstrip("v")
+        if tag_version != version_file:
+            fail(f"version drift: git tag={tag_version} != VERSION={version_file}")
+        elif tag_version != pkg_version:
+            fail(f"version drift: git tag={tag_version} != package.json={pkg_version}")
+        else:
+            ok(f"git tag matches version triple ({tag_version})")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="100x-dev repo consistency checker")
+    ap.add_argument("--tag", default=os.environ.get("TAG", ""),
+                    help="git tag (e.g. v2.0.4) to include in the version-triple check")
+    args = ap.parse_args()
+
+    counts = check_modules()
+    counts["plugins"] = check_plugins()
+    check_readme_counts(counts)
+    check_evals()
+    check_version_triple(args.tag or None)
+
+    print("\n".join(f"  ✓ {n}" for n in notes))
+    if failures:
+        print("\n".join(f"  ✗ {f}" for f in failures), file=sys.stderr)
+        print(f"\nmeta-check: {len(failures)} failure(s)", file=sys.stderr)
+        return 1
+    print("\nmeta-check: all checks passed ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/meta-check.test.js
+++ b/test/meta-check.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Verifies scripts/meta-check.py — the repo drift gate (issue #23):
+//   - passes on the real repo (counts, frontmatter, evals, version triple all agree)
+//   - fails (exit 1) when the git tag disagrees with the version triple
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+
+const REPO = path.resolve(__dirname, '..')
+const SCRIPT = path.join(REPO, 'scripts', 'meta-check.py')
+
+function run(args = []) {
+  return spawnSync('python3', [SCRIPT, ...args], { cwd: REPO, encoding: 'utf8' })
+}
+
+test('meta-check passes on the current repo state', () => {
+  const r = run()
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`)
+  assert.match(r.stdout, /all checks passed/)
+})
+
+test('meta-check reports the four README counts', () => {
+  const r = run()
+  for (const label of ['modules', 'slash commands', 'auto-trigger skills', 'plugins']) {
+    assert.match(r.stdout, new RegExp(`README '${label}' count`))
+  }
+})
+
+test('meta-check fails when the git tag disagrees with the version triple', () => {
+  const r = run(['--tag', 'v0.0.0-nope'])
+  assert.equal(r.status, 1, 'expected non-zero exit on tag mismatch')
+  assert.match(r.stderr, /version drift: git tag/)
+})

--- a/update.sh
+++ b/update.sh
@@ -21,30 +21,38 @@ for _arg in "$@"; do
 done
 
 # ── Plugin update function (always available) ─────────────────────────────────
+# Reads the plugin list from plugins/plugins.json (single source of truth). Each
+# entry is the fully-qualified `name@marketplace` id — the only form
+# `claude plugin update` accepts (bare names fail with "not found").
 run_plugin_updates() {
-  local _plugins=(
-    "frontend-design"
-    "superpowers"
-    "playwright"
-    "github"
-    "security-guidance"
-    "skill-creator"
-    "code-simplifier"
-    "pr-review-toolkit"
-    "hookify"
-    "claude-mem"
-    "understand-anything"
-    "ui-ux-pro-max"
-  )
-  local _ok=0 _err=0
+  local _plugins_file="$REPO_DIR/plugins/plugins.json"
+  local _plugins=()
+  while IFS= read -r _p; do
+    [ -n "$_p" ] && _plugins+=("$_p")
+  done < <(python3 -c "import json,sys; print('\n'.join(json.load(open(sys.argv[1])).get('plugins',[])))" "$_plugins_file" 2>/dev/null)
+
+  if [ "${#_plugins[@]}" -eq 0 ]; then
+    echo -e "  ${YELLOW}→ Plugins: no entries found in plugins.json — skipping${NC}"
+    return 0
+  fi
+
+  local _ok=0 _failed=()
   for _p in "${_plugins[@]}"; do
     if claude plugin update "$_p" >/dev/null 2>&1; then
       (( _ok++ )) || true
     else
-      (( _err++ )) || true
+      _failed+=("$_p")
     fi
   done
-  echo -e "  ${GREEN}→ Plugins: $_ok updated, $_err skipped ✓${NC}"
+
+  if [ "${#_failed[@]}" -eq 0 ]; then
+    echo -e "  ${GREEN}→ Plugins: $_ok updated ✓${NC}"
+  else
+    echo -e "  ${GREEN}→ Plugins: $_ok updated${NC}, ${YELLOW}${#_failed[@]} failed:${NC}"
+    for _p in "${_failed[@]}"; do
+      echo -e "      ${YELLOW}• $_p${NC}"
+    done
+  fi
 }
 
 if [ "$PLUGINS_ONLY" = true ]; then


### PR DESCRIPTION
Theme 3 of the [2026-05-31 power-up review](docs/superpowers/specs/2026-05-31-100x-powerup-review-design.md). Closes #23.

## Correctness drift (all verified)
- **`package.json` 2.0.1 → 2.0.4** — the npm-published version was 3 releases behind `VERSION`/tag.
- **`plugins.json` `plugins[]` now lists all 12** (added `understand-anything@understand-anything`, `ui-ux-pro-max@ui-ux-pro-max-skill`) so fresh installs enable them instead of only 10.
- **`update.sh` `run_plugin_updates()` reads the plugin list from `plugins.json`** (single source of truth) using fully-qualified `name@marketplace` ids.
  - **Worse than the spec captured:** the old hardcoded *bare-name* list silently failed for **every** plugin — `claude plugin update <bare-name>` errors `Plugin "<name>" not found`; only the qualified form works (verified live against the CLI). Failures are now printed by name instead of bucketed as "skipped".
- **gate/pr gate-count wording** reconciled to "all gates" (Gates 4–5 are conditional).

## New enforcement — the meta-CI gate
- **`scripts/meta-check.py`** — parses all 64 module frontmatter (fails on malformed/missing `name`/`description`), asserts every README count mention (modules/slash/skills/plugins) matches the repo, validates all 32 `evals.json`, and asserts the `VERSION == package.json == tag` triple. Also rejects bare/unknown-marketplace plugin ids so the update bug can't regress.
- **`.github/workflows/meta.yml`** — repo self-CI, deliberately **separate** from the `github-actions/ci.yml` *template* (per the review's adversarial note). Runs meta-check + the generator/adapter tests on every PR and push to main.
- **`.github/workflows/release.yml`** — pre-release version-triple guard (safe `env:` pattern).
- **`test/meta-check.test.js`** — locks in the drift-gate behavior.

Also added `__pycache__/` to `.gitignore`. CHANGELOG has an `[Unreleased]` section for the next `/release` to promote to 2.0.5.

## Acceptance criteria
- [x] VERSION, package.json, and tag agree; release.yml fails on mismatch.
- [x] Fresh install enables 12 plugins; update.sh reads the list from plugins.json.
- [x] gate/pr gate-count wording is consistent.
- [x] CI meta job runs on PRs and catches drift before merge.

## Verification
- `node --test test/*.test.js` → **25/25 pass**
- `python3 scripts/meta-check.py` → all checks pass; fails correctly on a mismatched `--tag`
- bare `claude plugin update ui-ux-pro-max` → not found; qualified id → success
- `run_plugin_updates` smoke test (stubbed claude) → "11 updated, 1 failed" with the failing id named
- `bash -n update.sh` clean

> Why this lands first among the remaining P0s: the spec's sequencing wants this meta-CI gate to exist **before** the higher-blast-radius themes (#24 eval harness, #25 fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
