### PR TITLE
feat: enforcing hooks (#22) + eval harness & trigger-overlap lint (#24)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,111 @@
+# 100x Dev — repo self-CI (skill evals + trigger-overlap).
+# Distinct from .github/workflows/meta.yml (drift/consistency) and from
+# github-actions/ci.yml (a TEMPLATE users copy into their own projects).
+#
+# Grading itself is done by the /eval skill (Haiku 4.5 over parallel subagents), which
+# needs a model and so runs interactively — not here. CI does the deterministic half:
+# fail on NEW trigger overlaps, and validate + inventory the evals of changed modules
+# (per-PR) or all modules (nightly), posting the result.
+name: Evals
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "modules/**"
+      - "scripts/eval-harness.py"
+      - "scripts/trigger-overlap.py"
+      - "scripts/trigger-overlap-allow.txt"
+      - ".github/workflows/evals.yml"
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "0 7 * * *" # nightly full sweep (07:00 UTC)
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  trigger-overlap:
+    name: Trigger-overlap lint
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Fail on new (non-allow-listed) trigger overlaps
+        run: python3 scripts/trigger-overlap.py --strict
+
+  changed-evals:
+    name: Validate + inventory changed-module evals
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # need the base branch for `git diff base...HEAD`
+
+      - name: Validate changed-module evals
+        id: validate
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python3 scripts/eval-harness.py validate --changed "origin/${BASE_REF}"
+
+      - name: Build eval inventory report
+        if: always()
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          BASE="origin/${BASE_REF}"
+          {
+            echo "## 🧪 Skill evals — changed modules"
+            echo
+            echo "Structural validation + the case/assertion inventory for modules touched"
+            echo "on this branch. Run \`/eval --changed $BASE\` locally to grade them"
+            echo "(Haiku 4.5 over parallel subagents) and get a pass/fail scorecard."
+            echo
+            echo '```'
+            python3 scripts/eval-harness.py validate --changed "$BASE" 2>&1 || true
+            echo '```'
+            echo
+            echo '<details><summary>Case / assertion work-list</summary>'
+            echo
+            echo '```'
+            python3 scripts/eval-harness.py plan --changed "$BASE" 2>&1 || true
+            echo '```'
+            echo
+            echo '</details>'
+          } | tee eval-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post report to PR
+        # Same-repo PRs only — forked PRs get a read-only token and can't comment.
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body-file eval-report.md --edit-last --create-if-none \
+          || gh pr comment "$PR_NUMBER" --body-file eval-report.md
+
+  nightly:
+    name: Nightly full eval sweep
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Validate all eval files
+        run: python3 scripts/eval-harness.py validate --all
+      - name: Inventory all evals to the run summary
+        if: always()
+        run: |
+          {
+            echo "## 🧪 Nightly skill-eval sweep"
+            echo
+            echo '```'
+            python3 scripts/eval-harness.py validate --all 2>&1 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Trigger-overlap report
+        if: always()
+        run: python3 scripts/trigger-overlap.py >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ Correctness & drift hardening (issue #23) — no breaking changes.
 - **`.github/workflows/release.yml`** — added a pre-release version-triple guard that fails the release if `VERSION`, `package.json`, and the tag disagree.
 - **`test/meta-check.test.js`** — tests for the drift gate.
 
+Enforcing hooks (issue #22) — opt-in; no behavior change unless enabled.
+
+### Added
+- **`hooks/`** — first-party hook pack (plain `python3`, no deps): `pretooluse-gate.py` blocks `git commit`/`git push` unless `/gate` recorded a pass for the current tree; `pretooluse-secret-scan.py` blocks writes containing obvious credentials; `posttooluse-lint.py` (advisory lint-on-save) and `permission-router.py` (auto-approve read-only Bash, optional model escalation) ship off by default. `gate-pass.py` records the pass; `hooks/hooks.manifest.json` is the single source of truth.
+- **`adapters/lib/modules.py emit-hooks [--sync]`** — idempotent, declarative merge of the hook pack into `~/.claude/settings.json` (same pattern as the plugin merge); per-hook toggles via `HOOK_GATE`/`HOOK_SECRET`/`HOOK_LINT`/`HOOK_ROUTER`. `--sync` only refreshes hooks already present.
+- **`install.sh`** — new opt-in *Hooks* component with a per-hook selection menu; **`update.sh`** refreshes installed hooks on update.
+- **`test/hooks.test.js`** — covers secret-scan, the gate→commit contract, the router, and idempotent merges.
+
+### Changed
+- **Gate cache is now keyed on a tree token** (HEAD + tracked diff + untracked status) instead of a bare HEAD, closing the stale-cache-for-a-dirty-tree / post-rebase hole. `modules/gate/SKILL.md` records the pass via `gate-pass.py`; `modules/commit/SKILL.md` Phase 0 checks the same token.
+- **`modules/subagents/SKILL.md`** — the permission-routing section now references the real `hooks/permission-router.py` artifact (was prose), fixes the stale `code.claude.com/docs` URL, and marks `ctrl+b` as Claude-Code-specific.
+
+Eval harness (issue #24) — wires up the 32 dormant `evals.json`.
+
+### Added
+- **`scripts/eval-harness.py`** — discovers, validates, and inventories the per-module `evals.json`; emits the case/assertion work-list the `/eval` skill grades; renders a per-assertion pass/fail scorecard from graded results (`validate` / `plan` / `score`, with `--module` / `--all` / `--changed` selectors). No model calls — runs anywhere.
+- **`scripts/trigger-overlap.py` + `scripts/trigger-overlap-allow.txt`** — deterministic trigger-overlap lint (overlap-coefficient over description trigger tokens); flags the known overlapping pairs (CRO family, conversion-copy⇄copywriting, systems-architect⇄enterprise-design), `--strict` fails only on new (non-allow-listed) overlaps.
+- **`modules/eval/`** — new `/eval` skill: fans eval cases out to parallel subagents and has Haiku 4.5 grade each assertion into a scorecard. (Counts: 65 modules / 26 slash commands / 39 auto-trigger skills.)
+- **`.github/workflows/evals.yml`** — repo self-CI (distinct from `meta.yml` and the `github-actions/ci.yml` template): trigger-overlap `--strict` on every PR, changed-module eval validation + inventory posted to the PR, nightly full sweep.
+- **`test/eval-harness.test.js`, `test/trigger-overlap.test.js`** — cover validation, planning, scoring, and overlap detection.
+
 ---
 
 ## [2.0.4] — 2026-05-15

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![npm](https://img.shields.io/npm/v/100x-dev?style=flat-square&color=red)](https://www.npmjs.com/package/100x-dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 
-**One source of truth.** 64 modules generate native config for **Claude Code · Cursor · Codex · Windsurf · Copilot · Gemini · Antigravity**. Quality gates run on every commit.
+**One source of truth.** 65 modules generate native config for **Claude Code · Cursor · Codex · Windsurf · Copilot · Gemini · Antigravity**. Quality gates run on every commit.
 
-<img src="assets/postcard-stack.png" alt="100x-dev stack at a glance — 12 plugins, 25 slash commands, 39 auto-trigger skills" width="100%" />
+<img src="assets/postcard-stack.png" alt="100x-dev stack at a glance — 12 plugins, 26 slash commands, 39 auto-trigger skills" width="100%" />
 
 </div>
 
@@ -60,7 +60,7 @@ Every `/commit` and `/push` runs a 5-point gate — tests, security, build, Dock
 
 | | |
 |---|---|
-| **64 modules** | 25 slash commands (`/commit`, `/spec`, `/grill`, `/db` …) + 39 auto-trigger skills (copywriting, seo-audit, fix-bugs …) |
+| **65 modules** | 26 slash commands (`/commit`, `/spec`, `/grill`, `/db`, `/eval` …) + 39 auto-trigger skills (copywriting, seo-audit, fix-bugs …) |
 | **12 plugins** | superpowers, frontend-design, playwright, github, hookify, claude-mem, understand-anything, ui-ux-pro-max, … |
 | **7 database engines** | Postgres, Cloud SQL, Snowflake, Databricks, Athena, Presto, Oracle — one `/db` interface |
 | **27 SaaS CLIs** | `/connect` installs + authenticates GitHub, AWS, Stripe, Supabase, … from `.env` |

--- a/adapters/lib/modules.py
+++ b/adapters/lib/modules.py
@@ -9,6 +9,11 @@ Used by all adapters. Outputs JSON to stdout with one of these subcommands:
                                when over budget.
   emit-cursor <project_dir>  — write .cursor/rules/<slug>.mdc per module
   emit-claude-code           — write ~/.claude/skills/<slug>/* + ~/.claude/commands/<slug>.md
+  emit-hooks [--sync]        — idempotently merge first-party hooks into
+                               ~/.claude/settings.json from hooks/hooks.manifest.json.
+                               Each hook is enabled per its manifest `default`, overridable
+                               by its `toggle_env` env var (1/true=on, 0/false=off).
+                               --sync only refreshes hooks already present (used on update).
 """
 from __future__ import annotations
 
@@ -268,6 +273,101 @@ def cmd_emit_claude_code():
     print(f"wrote {skill_count} skills + {cmd_count} slash command aliases")
 
 
+HOOKS_DIR = REPO / "hooks"
+
+
+def _hook_command(script: str) -> str:
+    return f'python3 "{HOOKS_DIR / script}"'
+
+
+def _hook_enabled(hook: dict) -> bool:
+    """manifest `default`, overridden by the hook's `toggle_env` env var if set."""
+    env = hook.get("toggle_env")
+    if env and env in os.environ:
+        val = os.environ[env].strip().lower()
+        if val in ("1", "true", "yes", "on"):
+            return True
+        if val in ("0", "false", "no", "off", ""):
+            return False
+    return bool(hook.get("default"))
+
+
+def _command_present(entries: list, command: str) -> bool:
+    return any(
+        h.get("command") == command
+        for e in entries
+        for h in e.get("hooks", [])
+    )
+
+
+def _strip_command(entries: list, command: str) -> list:
+    """Remove our command from every entry; drop entries left with no hooks."""
+    out = []
+    for e in entries:
+        kept = [h for h in e.get("hooks", []) if h.get("command") != command]
+        if kept:
+            out.append({**e, "hooks": kept})
+    return out
+
+
+def cmd_emit_hooks(sync: bool = False):
+    """Idempotently merge first-party hooks into settings.json (declarative).
+
+    For each manifest hook we strip any existing copy of its command, then re-add a
+    single entry when it should be enabled — so re-running never duplicates entries and
+    flipping a toggle off removes the hook. `sync` keeps only hooks already present
+    (used on update, so we never silently enable a hook the user opted out of).
+    """
+    manifest = json.loads((HOOKS_DIR / "hooks.manifest.json").read_text())
+    hooks_spec = manifest.get("hooks", [])
+
+    settings_file = Path(
+        os.environ.get("SETTINGS_FILE")
+        or os.path.expanduser("~/.claude/settings.json")
+    )
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        settings = json.loads(settings_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        settings = {}
+
+    settings_hooks = settings.setdefault("hooks", {})
+    added, kept, removed = [], [], []
+
+    for hook in hooks_spec:
+        command = _hook_command(hook["script"])
+        event = hook["event"]
+        entries = settings_hooks.get(event, [])
+        was_present = _command_present(entries, command)
+        entries = _strip_command(entries, command)  # dedupe / declarative reset
+
+        keep = was_present if sync else _hook_enabled(hook)
+        if keep:
+            entries.append({
+                "matcher": hook["matcher"],
+                "hooks": [{"type": "command", "command": command}],
+            })
+            (kept if was_present else added).append(hook["id"])
+        elif was_present:
+            removed.append(hook["id"])
+
+        if entries:
+            settings_hooks[event] = entries
+        elif event in settings_hooks:
+            del settings_hooks[event]
+
+    settings_file.write_text(json.dumps(settings, indent=2))
+
+    parts = []
+    if added:
+        parts.append(f"added {len(added)} ({', '.join(added)})")
+    if kept:
+        parts.append(f"refreshed {len(kept)}")
+    if removed:
+        parts.append(f"removed {len(removed)} ({', '.join(removed)})")
+    print(f"hooks: {'; '.join(parts) if parts else 'no changes'} → {settings_file}")
+
+
 def main(argv: list[str]):
     if len(argv) < 2:
         print(__doc__, file=sys.stderr)
@@ -281,6 +381,8 @@ def main(argv: list[str]):
         cmd_emit_cursor(argv[2])
     elif cmd == "emit-claude-code":
         cmd_emit_claude_code()
+    elif cmd == "emit-hooks":
+        cmd_emit_hooks(sync="--sync" in argv[2:])
     else:
         print(f"unknown command: {cmd}", file=sys.stderr)
         return 2

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,47 @@
+# 100x-dev — First-party enforcing hooks
+
+These hooks turn the repo's headline guarantees from prose into enforcement. They are
+**opt-in**: `install.sh` offers a *Hooks* component with a per-hook toggle, and you can
+re-run the installer (or `100x-dev update`) any time to change the selection. Nothing
+here runs unless you enable it.
+
+All hooks are plain `python3` scripts (no third-party deps) that read the Claude Code
+hook event from stdin. They live at `~/100x-dev/hooks/` after install and are wired into
+`~/.claude/settings.json` by the generator command `python3 adapters/lib/modules.py
+emit-hooks` — the same idempotent-merge pattern used for plugins.
+
+| Hook | Event · matcher | Default | What it does |
+|------|-----------------|---------|--------------|
+| `pretooluse-gate.py` | PreToolUse · `Bash` | **on** | Blocks `git commit` / `git push` unless `/gate` recorded a pass for the current tree. |
+| `pretooluse-secret-scan.py` | PreToolUse · `Write\|Edit\|MultiEdit` | **on** | Blocks writes containing obvious credentials (API keys, private keys, high-entropy secrets). |
+| `posttooluse-lint.py` | PostToolUse · `Write\|Edit\|MultiEdit` | off | Advisory lint-on-save; never blocks. |
+| `permission-router.py` | PreToolUse · `Bash` | off | Auto-approves known read-only commands; optionally routes ambiguous ones to a model. |
+
+## The gate ↔ commit contract
+
+`pretooluse-gate.py` and `/gate` share a cache under `~/.100x-dev/gate-cache/`. The cache
+key is a sha256 over **HEAD + tracked diff + untracked status**, so a recorded pass is
+invalidated the instant the tree changes or HEAD moves. Flow:
+
+1. You run `/gate`. Its final step (when ALL gates pass) calls
+   `python3 ~/100x-dev/hooks/gate-pass.py`, which records the current tree token.
+2. You commit. `pretooluse-gate.py` recomputes the token and compares. Match → allow;
+   otherwise it blocks and tells you to re-run `/gate`.
+
+This closes the "stale cache for a dirty tree / post-rebase HEAD" hole: editing *any*
+tracked or untracked file after the gate re-arms the block.
+
+## Runtime escape hatches
+
+- `HOOK_SECRET_SCAN=off` — disable the secret scan for the current session.
+- `HOOK_LINT_ON_SAVE=off` — silence lint-on-save.
+- `HOOK_ROUTER_MODEL=claude-haiku-4-5` — enable the router's optional model tier (needs
+  the `claude` CLI); leave unset to use the deterministic allowlist only.
+
+## Adding / changing hooks
+
+Edit `hooks.manifest.json` (the single source of truth), then re-run `emit-hooks`. The
+merge is idempotent and declarative: enabled hooks are ensured present, disabled hooks
+are removed — re-running never duplicates entries.
+
+Hook docs: <https://docs.claude.com/en/docs/claude-code/hooks>

--- a/hooks/gate-pass.py
+++ b/hooks/gate-pass.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Record (or print) the gate-state token for the current working tree.
+
+Called by the /gate skill as its final step once ALL gates report PASSED, and by
+/commit's Phase-0 cache check. Writes the token (sha256 of HEAD + tracked diff +
+untracked status) to the single-file cache ~/.100x-dev/gate-cache so the gate-on-commit
+hook (pretooluse-gate.py) will allow the next commit/push — and only until the tree
+changes.
+
+Usage:
+  python3 gate-pass.py [repo_dir]            # compute token for repo_dir (default: .) and record it
+  python3 gate-pass.py --print [repo_dir]    # print the token only; do not write the cache
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from hooklib import gate_state_token, repo_root, write_cache  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    print_only = "--print" in args
+    positional = [a for a in args if not a.startswith("--")]
+    start = positional[0] if positional else "."
+
+    root = repo_root(start)
+    if not root:
+        sys.stderr.write("gate-pass: not inside a git repository — nothing recorded.\n")
+        return 1
+
+    token = gate_state_token(root)
+    if print_only:
+        print(token)
+        return 0
+
+    write_cache(token)
+    print(f"✓ gate pass recorded for {root}")
+    print("  (valid until the working tree changes or HEAD moves)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/hooks/hooks.manifest.json
+++ b/hooks/hooks.manifest.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Single source of truth for 100x-dev first-party hooks. `emit-hooks` (adapters/lib/modules.py) reads this to idempotently merge hook entries into ~/.claude/settings.json. `default` sets whether a hook is enabled unless its `toggle_env` env var overrides (1/true = on, 0/false = off). install.sh sets these toggles from its hooks menu.",
+  "hooks": [
+    {
+      "id": "gate-on-commit",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "script": "pretooluse-gate.py",
+      "default": true,
+      "toggle_env": "HOOK_GATE",
+      "description": "Block git commit/push unless /gate passed for the current tree."
+    },
+    {
+      "id": "secret-scan",
+      "event": "PreToolUse",
+      "matcher": "Write|Edit|MultiEdit",
+      "script": "pretooluse-secret-scan.py",
+      "default": true,
+      "toggle_env": "HOOK_SECRET",
+      "description": "Block writes that contain obvious hard-coded credentials."
+    },
+    {
+      "id": "lint-on-save",
+      "event": "PostToolUse",
+      "matcher": "Write|Edit|MultiEdit",
+      "script": "posttooluse-lint.py",
+      "default": false,
+      "toggle_env": "HOOK_LINT",
+      "description": "Advisory: run the project linter on saved files (never blocks)."
+    },
+    {
+      "id": "permission-router",
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "script": "permission-router.py",
+      "default": false,
+      "toggle_env": "HOOK_ROUTER",
+      "description": "Auto-approve known read-only commands; optionally route ambiguous ones to a model."
+    }
+  ]
+}

--- a/hooks/lib/hooklib.py
+++ b/hooks/lib/hooklib.py
@@ -1,0 +1,110 @@
+"""Shared helpers for 100x-dev first-party hooks.
+
+Every hook is a small python3 script invoked by Claude Code with a JSON event on
+stdin. This module centralises the three things they all need: reading that event,
+talking to git, and the gate-cache token contract that ties /gate to the
+gate-on-commit hook.
+
+The gate-cache token is a sha256 over (HEAD + tracked diff + porcelain status). It
+deliberately captures the *full* tree state — not just HEAD — so a pass recorded by
+/gate is invalidated the moment a tracked file changes, an untracked file appears,
+or HEAD moves (commit / rebase / pull). That closes the "stale cache for a dirty
+tree" hole called out in the power-up review.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Single global cache file (existing 100x-dev contract). Holds the gate-state token
+# of the last tree /gate passed on. The token itself encodes HEAD, so it is repo- and
+# tree-specific; switching repos or dirtying the tree simply fails the match (closed).
+CACHE_FILE = Path(os.path.expanduser("~/.100x-dev/gate-cache"))
+
+
+def read_event() -> dict:
+    """Parse the hook event JSON from stdin. Returns {} on empty / malformed input
+    so a misfire never crashes the user's commit."""
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def tool_input(event: dict) -> dict:
+    ti = event.get("tool_input")
+    return ti if isinstance(ti, dict) else {}
+
+
+def event_cwd(event: dict) -> str:
+    cwd = event.get("cwd")
+    return cwd if isinstance(cwd, str) and cwd else os.getcwd()
+
+
+def git(args: list[str], cwd: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=False
+    )
+
+
+def repo_root(cwd: str) -> str | None:
+    r = git(["rev-parse", "--show-toplevel"], cwd)
+    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else None
+
+
+def gate_state_token(root: str) -> str:
+    """Stable fingerprint of the working tree: HEAD + tracked diff + untracked status."""
+    head = git(["rev-parse", "HEAD"], root).stdout.strip() or "no-head"
+    diff = git(["diff", "HEAD"], root).stdout
+    status = git(["status", "--porcelain"], root).stdout
+    h = hashlib.sha256()
+    for part in (head, diff, status):
+        h.update(part.encode("utf-8", "replace"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def read_cache() -> str | None:
+    try:
+        return CACHE_FILE.read_text().strip() or None
+    except OSError:
+        return None
+
+
+def write_cache(token: str) -> None:
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(token + "\n")
+
+
+def allow() -> int:
+    """Defer to Claude Code's normal permission flow (no decision)."""
+    return 0
+
+
+def block(reason: str) -> int:
+    """Block the tool call. stderr is surfaced to Claude as the reason."""
+    sys.stderr.write(reason.rstrip() + "\n")
+    return 2
+
+
+def auto_approve(reason: str) -> int:
+    """Emit a PreToolUse allow decision so the call runs without a prompt."""
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    return 0

--- a/hooks/permission-router.py
+++ b/hooks/permission-router.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) — the subagents permission router, as a real artifact.
+
+The subagents skill long described "route permission requests to a model to auto-approve
+safe ones" but shipped nothing. This is that hook.
+
+Tier 1 (always, offline): a deterministic allowlist auto-approves obviously read-only
+commands (ls, cat, git status, grep, …) so safe calls don't prompt.
+Tier 2 (optional): when HOOK_ROUTER_MODEL is set and the `claude` CLI is available,
+ambiguous commands are classified by a cheap model (default Haiku 4.5); a clear "safe"
+verdict auto-approves, anything else defers to the human. Routing only ever *grants*
+permission it is confident about — it never blocks, so the normal prompt remains the
+safe default for everything it's unsure about.
+
+Exit 0 with an allow decision = auto-approved. Exit 0 with no output = defer to the
+normal permission prompt. This hook never blocks.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from hooklib import allow, auto_approve, read_event, tool_input  # noqa: E402
+
+# Binaries with no write/network side effects. git is handled separately (subcommand-aware).
+_SAFE_BINS = {
+    "ls", "pwd", "cat", "head", "tail", "wc", "echo", "grep", "egrep", "fgrep", "rg",
+    "find", "which", "type", "file", "stat", "date", "whoami", "id", "uname", "hostname",
+    "env", "printenv", "tree", "du", "df", "basename", "dirname", "realpath", "readlink",
+    "true", "sort", "uniq", "cut", "column", "diff", "tldr", "man",
+}
+_SAFE_GIT_SUBCMDS = {
+    "status", "log", "diff", "show", "branch", "remote", "rev-parse", "describe",
+    "ls-files", "ls-tree", "blame", "shortlog", "tag", "config", "cat-file", "reflog",
+}
+# Constructs that can mutate state or chain into something risky → never auto-approve.
+_DANGEROUS = re.compile(r"(>>|>|<|\$\(|`|\bsudo\b|\brm\b|\bmv\b|\bcp\b|\bdd\b|\bchmod\b|\bchown\b|\bkill\b|\bcurl\b|\bwget\b)")
+_SEGMENT_SPLIT = re.compile(r"&&|\|\||;|\|")
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*$")
+
+
+def is_deterministically_safe(cmd: str) -> bool:
+    if not cmd.strip() or _DANGEROUS.search(cmd):
+        return False
+    for segment in _SEGMENT_SPLIT.split(cmd):
+        tokens = segment.split()
+        # Drop leading `VAR=value` env prefixes.
+        while tokens and _ENV_ASSIGN.match(tokens[0]):
+            tokens = tokens[1:]
+        if not tokens:
+            continue
+        binary = Path(tokens[0]).name
+        if binary == "git":
+            sub = next((t for t in tokens[1:] if not t.startswith("-")), "")
+            if sub not in _SAFE_GIT_SUBCMDS:
+                return False
+        elif binary not in _SAFE_BINS:
+            return False
+    return True
+
+
+def model_says_safe(cmd: str) -> bool:
+    """Optional Tier 2: ask a cheap model. Only a confident YES grants permission."""
+    model = os.environ.get("HOOK_ROUTER_MODEL", "").strip()
+    if not model or not shutil.which("claude"):
+        return False
+    prompt = (
+        "You are a permission gate for a shell command. Reply with exactly one word: "
+        "SAFE if the command is read-only with no destructive, network, or credential "
+        "side effects, otherwise UNSAFE.\n\nCommand:\n" + cmd
+    )
+    try:
+        r = subprocess.run(
+            ["claude", "-p", "--model", model, prompt],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return r.returncode == 0 and r.stdout.strip().upper().startswith("SAFE")
+
+
+def main() -> int:
+    cmd = tool_input(read_event()).get("command", "")
+    if not isinstance(cmd, str) or not cmd:
+        return allow()
+    if is_deterministically_safe(cmd):
+        return auto_approve("read-only command auto-approved by 100x-dev permission router")
+    if model_says_safe(cmd):
+        return auto_approve(f"classified safe by {os.environ['HOOK_ROUTER_MODEL']} via permission router")
+    return allow()  # defer to the normal prompt — never block
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/posttooluse-lint.py
+++ b/hooks/posttooluse-lint.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""PostToolUse(Write|Edit) — advisory lint-on-save (optional, opt-in).
+
+After Claude writes or edits a file, run the project's linter on just that file if one
+is available, and surface any complaints. This is ADVISORY: it always exits 0 so it
+never blocks the edit — the blocking quality bar is /gate. Disabled by default; enable
+it from install.sh's hooks menu.
+
+Runs nothing if no matching linter is installed, so it's a no-op on minimal machines.
+Set HOOK_LINT_ON_SAVE=off to silence at runtime.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from hooklib import event_cwd, read_event, tool_input  # noqa: E402
+
+
+def _run(cmd: list[str], cwd: str) -> str:
+    try:
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return (r.stdout + r.stderr).strip() if r.returncode != 0 else ""
+
+
+def lint(path: str, cwd: str) -> str:
+    ext = Path(path).suffix.lower()
+    if ext == ".py":
+        if shutil.which("ruff"):
+            return _run(["ruff", "check", path], cwd)
+        return _run([sys.executable, "-m", "py_compile", path], cwd)
+    if ext in (".js", ".jsx", ".ts", ".tsx"):
+        if Path(cwd, "node_modules", ".bin", "eslint").exists():
+            return _run([str(Path(cwd, "node_modules", ".bin", "eslint")), path], cwd)
+    if ext in (".sh", ".bash") and shutil.which("shellcheck"):
+        return _run(["shellcheck", path], cwd)
+    return ""
+
+
+def main() -> int:
+    if os.environ.get("HOOK_LINT_ON_SAVE", "").lower() == "off":
+        return 0
+    event = read_event()
+    path = tool_input(event).get("file_path", "")
+    if not isinstance(path, str) or not path or not Path(path).exists():
+        return 0
+    out = lint(path, event_cwd(event))
+    if out:
+        sys.stderr.write(f"⚠ 100x-dev lint-on-save ({Path(path).name}):\n{out}\n")
+    return 0  # advisory only — never block
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/pretooluse-gate.py
+++ b/hooks/pretooluse-gate.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) — block `git commit` / `git push` unless /gate passed.
+
+Turns the headline promise "nothing ships without passing the gate" from honor-system
+prose into enforcement. /gate records a pass for the current tree (hooks/gate-pass.py);
+this hook recomputes that fingerprint at commit time and blocks if it doesn't match.
+
+Exit 0 = allow (not a commit/push, not a git repo, or gate passed for this exact tree).
+Exit 2 = block with an explanation Claude sees.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from hooklib import (  # noqa: E402
+    allow, block, event_cwd, gate_state_token, git, read_cache, read_event, repo_root, tool_input,
+)
+
+# A `git ... commit` or `git ... push` invocation anywhere in the command line.
+# Tolerates global flags (`git -C dir commit`, `git --no-pager push`).
+_COMMIT_OR_PUSH = re.compile(r"\bgit\b[^&|;\n]*?\b(commit|push)\b")
+# Read-only / safe git subcommands that happen to contain the word, e.g.
+# `git log --grep=commit` or `git config push.default` — never gated.
+_SAFE_PREFIX = re.compile(r"\bgit\b\s+(?:-\S+\s+)*(log|show|config|help|diff|status|remote|branch)\b")
+
+
+def is_commit_or_push(cmd: str) -> bool:
+    if not _COMMIT_OR_PUSH.search(cmd):
+        return False
+    # If the only git invocation is a clearly read-only one, don't gate.
+    if _SAFE_PREFIX.search(cmd) and not re.search(r"\bgit\b\s+(?:-\S+\s+)*(commit|push)\b", cmd):
+        return False
+    return True
+
+
+def main() -> int:
+    event = read_event()
+    cmd = tool_input(event).get("command", "")
+    if not isinstance(cmd, str) or not is_commit_or_push(cmd):
+        return allow()
+
+    cwd = event_cwd(event)
+    root = repo_root(cwd)
+    if not root:
+        return allow()  # not a git repo — nothing to gate
+
+    # `git commit --amend` with no tree change, and pushes, are still subject to the
+    # gate: the cache is keyed on HEAD+tree so a fresh pass is always required.
+    token = gate_state_token(root)
+    cached = read_cache()
+    if cached and cached == token:
+        return allow()
+
+    head = git(["rev-parse", "--short", "HEAD"], root).stdout.strip() or "(no commits)"
+    return block(
+        "⛔ 100x-dev gate hook: the quality gate has not passed for the current tree.\n"
+        f"   repo: {root}  @ {head}\n"
+        "   Run /gate and let ALL gates pass, then retry the commit/push.\n"
+        "   (/gate records a pass for the exact tree state; any later edit re-arms this block.)"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/pretooluse-secret-scan.py
+++ b/hooks/pretooluse-secret-scan.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""PreToolUse(Write|Edit) — block writes that contain obvious hard-coded credentials.
+
+A fast, dependency-free regex/heuristic scan. It is intentionally tuned for *obvious*
+secrets (provider key formats, private-key blocks, high-entropy assignments) and skips
+clear placeholders so it doesn't cry wolf on `.env.example` style files. It is a
+backstop, not a replacement for the /security gate.
+
+Exit 0 = allow.  Exit 2 = block, listing what tripped.
+Set HOOK_SECRET_SCAN=off to disable at runtime without uninstalling.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+from hooklib import allow, block, read_event, tool_input  # noqa: E402
+
+# (label, compiled pattern). Each pattern targets a credential format precise enough
+# that a match is almost certainly a real secret, not prose.
+_PROVIDER_PATTERNS = [
+    ("AWS access key id",       re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("AWS secret access key",   re.compile(r"(?i)aws_secret_access_key\s*[=:]\s*['\"]?[A-Za-z0-9/+]{40}\b")),
+    ("private key block",       re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----")),
+    ("OpenAI API key",          re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")),
+    ("GitHub token",            re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b")),
+    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{59,}\b")),
+    ("Slack token",             re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+    ("Google API key",          re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b")),
+    ("Stripe live secret key",  re.compile(r"\b(?:sk|rk)_live_[A-Za-z0-9]{20,}\b")),
+    ("Slack webhook",           re.compile(r"https://hooks\.slack\.com/services/T[A-Za-z0-9]+/B[A-Za-z0-9]+/[A-Za-z0-9]+")),
+]
+
+# Generic `name = "value"` secret assignment with a high-entropy literal.
+_GENERIC_ASSIGN = re.compile(
+    r"(?i)\b(api[_-]?key|secret(?:[_-]?key)?|access[_-]?token|auth[_-]?token|password|passwd|client[_-]?secret)\b"
+    r"\s*[=:]\s*['\"]([^'\"]{16,})['\"]"
+)
+
+# Values that look like documentation, env-var indirection, or fillers — never secrets.
+_PLACEHOLDER = re.compile(
+    r"(?i)(example|changeme|placeholder|your[_-]?|xxxx|<[^>]+>|\$\{?[A-Z_]+\}?|"
+    r"process\.env|os\.environ|getenv|secret:|env:|\bredacted\b|\*{4,}|^.{0,3}$)"
+)
+
+
+def _looks_placeholder(value: str) -> bool:
+    if _PLACEHOLDER.search(value):
+        return True
+    # All one repeated character (e.g. "aaaaaaaaaaaaaaaa").
+    return len(set(value)) <= 2
+
+
+def scan(text: str) -> list[str]:
+    findings: list[str] = []
+    for label, pat in _PROVIDER_PATTERNS:
+        if pat.search(text):
+            findings.append(label)
+    for m in _GENERIC_ASSIGN.finditer(text):
+        if not _looks_placeholder(m.group(2)):
+            findings.append(f"hard-coded {m.group(1).lower()}")
+    # De-dupe while preserving order.
+    seen: set[str] = set()
+    return [f for f in findings if not (f in seen or seen.add(f))]
+
+
+def main() -> int:
+    if os.environ.get("HOOK_SECRET_SCAN", "").lower() == "off":
+        return allow()
+
+    event = read_event()
+    ti = tool_input(event)
+    # Write → content; Edit → new_string; MultiEdit → edits[].new_string.
+    chunks = [ti.get("content", ""), ti.get("new_string", "")]
+    for e in ti.get("edits", []) if isinstance(ti.get("edits"), list) else []:
+        if isinstance(e, dict):
+            chunks.append(e.get("new_string", ""))
+    text = "\n".join(c for c in chunks if isinstance(c, str))
+    if not text:
+        return allow()
+
+    findings = scan(text)
+    if not findings:
+        return allow()
+
+    path = ti.get("file_path", "(file)")
+    bullets = "\n".join(f"   • {f}" for f in findings)
+    return block(
+        f"⛔ 100x-dev secret-scan hook: refusing to write a likely credential into {path}\n"
+        f"{bullets}\n"
+        "   Move the secret to an env var / secret manager and reference it instead.\n"
+        "   False positive? Set HOOK_SECRET_SCAN=off for this session."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ INSTALL_MODULES=true
 INSTALL_PLUGINS=true
 INSTALL_SHELL=true
 INSTALL_TEMPLATES=true
+INSTALL_HOOKS=false   # enforcing hooks are opt-in (they change commit behavior)
 
 select_components() {
   echo ""
@@ -58,14 +59,18 @@ select_components() {
     fi
     echo "  [$([ "$INSTALL_SHELL" = true ] && echo "x" || echo " ")] 3) Shell        — aliases + shortcuts (cc, ccc, 100x-update, ...)"
     echo "  [$([ "$INSTALL_TEMPLATES" = true ] && echo "x" || echo " ")] 4) Templates   — project starters (node, python, docker)"
+    if [ "$TOOL_CLAUDE" = true ]; then
+      echo "  [$([ "$INSTALL_HOOKS" = true ] && echo "x" || echo " ")] 5) Hooks        — Claude Code only: enforce the gate on commit + secret-scan (opt-in)"
+    fi
     echo ""
-    read -rp "  Toggle (1-4) or press Enter to confirm: " choice || true
+    read -rp "  Toggle (1-5) or press Enter to confirm: " choice || true
 
     case "$choice" in
       1) INSTALL_MODULES=$([ "$INSTALL_MODULES" = true ] && echo false || echo true) ;;
       2) [ "$TOOL_CLAUDE" = true ] && INSTALL_PLUGINS=$([ "$INSTALL_PLUGINS" = true ] && echo false || echo true) ;;
       3) INSTALL_SHELL=$([ "$INSTALL_SHELL" = true ] && echo false || echo true) ;;
       4) INSTALL_TEMPLATES=$([ "$INSTALL_TEMPLATES" = true ] && echo false || echo true) ;;
+      5) [ "$TOOL_CLAUDE" = true ] && INSTALL_HOOKS=$([ "$INSTALL_HOOKS" = true ] && echo false || echo true) ;;
       "") break ;;
       *) echo "  Invalid choice." ;;
     esac
@@ -126,6 +131,42 @@ else:
 with open(settings_file, 'w') as f:
     json.dump(settings, f, indent=2)
 PYEOF
+}
+
+# ── Install enforcing hooks (Claude Code only) ──────────────────────────────
+
+install_hooks() {
+  [ "$TOOL_CLAUDE" = true ] || return 0
+  echo ""
+  echo "Installing enforcing hooks for Claude Code..."
+  echo "  These run via ~/.claude/settings.json. Pick which to enable:"
+  echo ""
+
+  # Defaults mirror hooks/hooks.manifest.json: gate + secret on, lint + router off.
+  local H_GATE=true H_SECRET=true H_LINT=false H_ROUTER=false
+  while true; do
+    echo "  [$([ "$H_GATE" = true ] && echo "x" || echo " ")] 1) gate-on-commit   — block git commit/push unless /gate passed for the tree"
+    echo "  [$([ "$H_SECRET" = true ] && echo "x" || echo " ")] 2) secret-scan      — block writes containing obvious credentials"
+    echo "  [$([ "$H_LINT" = true ] && echo "x" || echo " ")] 3) lint-on-save     — advisory lint after each edit (never blocks)"
+    echo "  [$([ "$H_ROUTER" = true ] && echo "x" || echo " ")] 4) permission-router — auto-approve known read-only Bash commands"
+    echo ""
+    read -rp "  Toggle (1-4) or press Enter to confirm: " hchoice || true
+    case "$hchoice" in
+      1) H_GATE=$([ "$H_GATE" = true ] && echo false || echo true) ;;
+      2) H_SECRET=$([ "$H_SECRET" = true ] && echo false || echo true) ;;
+      3) H_LINT=$([ "$H_LINT" = true ] && echo false || echo true) ;;
+      4) H_ROUTER=$([ "$H_ROUTER" = true ] && echo false || echo true) ;;
+      "") break ;;
+      *) echo "  Invalid choice." ;;
+    esac
+    echo ""
+  done
+
+  HOOK_GATE="$H_GATE" HOOK_SECRET="$H_SECRET" HOOK_LINT="$H_LINT" HOOK_ROUTER="$H_ROUTER" \
+    python3 "$REPO_DIR/adapters/lib/modules.py" emit-hooks
+
+  echo -e "  ${GREEN}→ Hooks merged into ~/.claude/settings.json ✓${NC}"
+  echo -e "  ${CYAN}→ Restart Claude Code to load hooks${NC}"
 }
 
 # ── Install shell aliases ───────────────────────────────────────────────────
@@ -198,6 +239,7 @@ echo "────────────────────────�
 
 [ "$INSTALL_MODULES" = true ] && install_modules
 [ "$INSTALL_PLUGINS" = true ] && [ "$TOOL_CLAUDE" = true ] && do_install_plugins
+[ "$INSTALL_HOOKS" = true ] && [ "$TOOL_CLAUDE" = true ] && install_hooks
 [ "$INSTALL_SHELL" = true ] && install_shell
 [ "$INSTALL_TEMPLATES" = true ] && install_templates
 

--- a/modules/commit/SKILL.md
+++ b/modules/commit/SKILL.md
@@ -16,17 +16,20 @@ Quality gate runs FIRST. **Do NOT commit if any gate fails.**
 
 ## Phase 0 — Quality Gate (MANDATORY)
 
-Check gate cache first — skip if already passed for this exact HEAD:
+Check gate cache first — skip if it already passed for this exact tree state. The
+cache is keyed on a tree token (HEAD + tracked diff + untracked files), not a bare
+HEAD, so a dirty or rebased tree never reuses a stale pass:
 
 ```bash
-HEAD=$(git rev-parse HEAD)
+TOKEN=$(python3 ~/100x-dev/hooks/gate-pass.py --print 2>/dev/null)
 CACHED=$(cat ~/.100x-dev/gate-cache 2>/dev/null)
-[ "$CACHED" = "$HEAD" ] && echo "Gate: skipped (already passed for $HEAD)" && GATE_DONE=true || GATE_DONE=false
+[ -n "$TOKEN" ] && [ "$CACHED" = "$TOKEN" ] && echo "Gate: skipped (already passed for this tree)" && GATE_DONE=true || GATE_DONE=false
 ```
 
-If `GATE_DONE=false`: run the **gate** workflow. On pass, cache the result:
+If `GATE_DONE=false`: run the **gate** workflow. On pass, record it (same token the
+gate-on-commit hook checks):
 ```bash
-echo "$HEAD" > ~/.100x-dev/gate-cache
+python3 ~/100x-dev/hooks/gate-pass.py
 ```
 
 Do NOT proceed until gate reports `✅ ALL GATES PASSED`. If any gate fails → STOP, fix, clear cache, re-run gate.

--- a/modules/eval/SKILL.md
+++ b/modules/eval/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: eval
+description: Run a module's evals to check it triggers correctly and produces good output. Use when the user wants to evaluate a skill, run evals, grade eval assertions, score skill quality, or asks "do my skills still trigger correctly" or "did this change break a skill". Fans eval cases out to parallel subagents and has Haiku 4.5 grade each assertion into a pass/fail scorecard.
+category: quality
+tier: on-demand
+slash_command: /eval
+allowed-tools: Bash Read Agent
+---
+
+# Eval — Run skill evals and score them
+
+Turns the dormant `modules/<slug>/evals/evals.json` files into a real, graded scorecard:
+does the skill trigger on its prompts, and does its output satisfy each assertion?
+
+The deterministic engine is `scripts/eval-harness.py` (discovery, validation, work-list,
+scorecard rendering — no model calls). **Grading is your job**: fan the cases out to
+subagents and have Haiku 4.5 judge every assertion with structured output. Installed path
+is `~/100x-dev/scripts/eval-harness.py`; in a checkout it's `scripts/eval-harness.py`.
+
+## Phase 0 — Pick the target
+
+```bash
+# one module, everything, or just what changed on this branch:
+python3 ~/100x-dev/scripts/eval-harness.py validate --module <slug>
+python3 ~/100x-dev/scripts/eval-harness.py validate --all
+python3 ~/100x-dev/scripts/eval-harness.py validate --changed origin/main
+```
+
+Fix any structural errors before grading — a malformed eval file can't be scored.
+
+## Phase 1 — Get the work-list
+
+```bash
+python3 ~/100x-dev/scripts/eval-harness.py plan --module <slug> --json
+```
+
+This emits `{ "modules": [ { "module", "cases": [ { id, prompt, expected_output,
+assertions[], files[] } ] } ] }`. Each `(case, assertion)` is one unit of work.
+
+## Phase 2 — Grade with parallel subagents (Haiku 4.5)
+
+For each case, dispatch **one subagent** (use the **subagents** skill / `Agent` tool, or a
+Workflow fan-out) that:
+
+1. **Runs the prompt against the skill.** Load the target skill (its SKILL.md) as
+   context, then answer the case `prompt` exactly as the assistant would — this is the
+   *candidate response*. Note whether the skill would have auto-triggered on that prompt
+   (trigger accuracy) separately from output quality.
+2. **Grades each assertion.** Spawn a Haiku 4.5 grader (`model: claude-haiku-4-5`) that,
+   given the prompt, the candidate response, the `expected_output`, and one assertion,
+   returns **structured output**:
+
+   ```json
+   { "module": "<slug>", "case_id": <id>, "assertion": "<text>", "passed": true|false, "reason": "<one line>" }
+   ```
+
+Run cases in parallel (independent), cap concurrency sanely, and collect every grader
+object into one results array. Default cheap (Haiku) and only escalate a genuinely
+ambiguous assertion to a stronger model.
+
+Write the collected array to a results file:
+
+```bash
+# results.json = the JSON array of grader objects from every subagent
+```
+
+## Phase 3 — Render the scorecard
+
+```bash
+python3 ~/100x-dev/scripts/eval-harness.py score --results results.json
+```
+
+Produces a per-assertion ✓/✗ scorecard with reasons, per-case and overall tallies, and
+exits non-zero if any assertion failed. Use `--json` for machine output.
+
+```
+=== marketing-psychology ===
+  case 1: 6/7 assertions passed
+    ✓ Checks for product-marketing-context.md
+    ✗ References specific mental models by name — named only two of the taxonomy
+scorecard: 41/43 assertions passed across 1 module(s)
+```
+
+## Trigger-overlap lint (no model needed)
+
+Catch skills that would fire on each other's prompts before they ever reach grading:
+
+```bash
+python3 ~/100x-dev/scripts/trigger-overlap.py            # report flagged pairs
+python3 ~/100x-dev/scripts/trigger-overlap.py --strict   # fail on NEW (non-allow-listed) overlaps
+```
+
+Intentional overlaps live in `scripts/trigger-overlap-allow.txt`. If a real change adds a
+new high-overlap pair, either differentiate the two descriptions or add the pair to the
+allow-list with a note.
+
+## Principles
+
+- **Default cheap.** Haiku grades; escalate only ambiguous assertions.
+- **Structured output, not prose.** Every grader returns the object above so the scorecard
+  is deterministic.
+- **Separate trigger accuracy from output quality.** A skill can answer well yet never
+  have triggered — report both.
+- **Per-PR vs nightly.** Grade only `--changed` modules on a PR; the nightly CI run covers
+  all modules that ship evals.

--- a/modules/gate/SKILL.md
+++ b/modules/gate/SKILL.md
@@ -187,3 +187,19 @@ If ANY gate fails:
 ```
 
 **Do NOT commit or push until the gate summary shows ALL GATES PASSED.**
+
+---
+
+## Record the pass (enables the gate-on-commit hook)
+
+**Only when the summary shows ALL GATES PASSED**, record the pass so the optional
+`gate-on-commit` hook will allow the next commit/push:
+
+```bash
+python3 ~/100x-dev/hooks/gate-pass.py 2>/dev/null || true
+```
+
+This writes a token for the **current tree state** (HEAD + tracked diff + untracked
+files) to `~/.100x-dev/gate-cache`. The token is invalidated the moment anything in the
+tree changes, so a later edit always re-arms the gate. If a gate **failed**, do NOT run
+this — leave the cache stale so the commit stays blocked.

--- a/modules/subagents/SKILL.md
+++ b/modules/subagents/SKILL.md
@@ -33,11 +33,23 @@ Offload heavy research or analysis to a subagent so the main agent's context sta
 - Main agent uses the summary, never sees the raw noise
 
 ### C. Permission Routing via Hook
-Route permission requests to a smarter model via a hook:
-- Hook intercepts permission requests
-- Sends to a model (e.g., Opus) to scan for attacks and auto-approve safe ones
-- Dangerous or ambiguous requests get flagged for human review
-- See: code.claude.com/docs for hook configuration
+Auto-approve obviously-safe tool calls so they don't interrupt with a prompt, while
+anything risky still falls through to human review. 100x-dev ships this as a real,
+installable artifact — not just advice:
+
+- **Artifact:** `~/100x-dev/hooks/permission-router.py` (a `PreToolUse` Bash hook).
+- **Tier 1 (offline):** a deterministic allowlist auto-approves read-only commands
+  (`ls`, `cat`, `git status`, `grep`, …); destructive/network/credential commands are
+  never auto-approved.
+- **Tier 2 (optional):** set `HOOK_ROUTER_MODEL=claude-haiku-4-5` (needs the `claude`
+  CLI) to route ambiguous commands to a cheap model; only a confident "safe" verdict
+  grants permission, so escalation to a deeper model (e.g. Opus 4.8) or a human is the
+  default for anything uncertain. The router **never blocks** — it only grants.
+- **Enable it:** re-run the installer and turn on the *permission-router* hook (it ships
+  off by default), or run `python3 ~/100x-dev/adapters/lib/modules.py emit-hooks` with
+  `HOOK_ROUTER=1`.
+- See `~/100x-dev/hooks/README.md` and the hooks docs:
+  <https://docs.claude.com/en/docs/claude-code/hooks>
 
 ## Usage Patterns
 
@@ -48,7 +60,7 @@ Route permission requests to a smarter model via a hook:
 # Parallel exploration
 "Use 5 subagents to map out every API endpoint and their dependencies"
 
-# Background agent
+# Background agent (Claude Code only)
 ctrl+b  →  runs current task in background agent
 ```
 
@@ -56,5 +68,5 @@ ctrl+b  →  runs current task in background agent
 
 - One focused task per subagent
 - Subagents return summaries, not raw data dumps
-- Use background agents (ctrl+b) for long-running tasks so you can keep working
+- Use background agents (ctrl+b, Claude Code only) for long-running tasks so you can keep working
 - Subagents are especially valuable for: codebase mapping, test generation, doc writing, and competitive analysis

--- a/scripts/eval-harness.py
+++ b/scripts/eval-harness.py
@@ -112,7 +112,10 @@ def load_evals(slug: str) -> tuple[dict | None, list[str]]:
 def cmd_validate(args) -> int:
     slugs = select(args)
     if not slugs:
-        print("validate: no modules selected (nothing changed?) — ok")
+        if args.changed is not None:
+            print("validate: no changed module ships evals — nothing to grade ✓")
+        else:
+            print("validate: no modules selected — ok")
         return 0
     all_errors: list[str] = []
     total_cases = total_assertions = 0

--- a/scripts/eval-harness.py
+++ b/scripts/eval-harness.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Eval harness for the per-module evals.json files (issue #24).
+
+Grading is done by the /eval skill, which fans each case out to parallel subagents and
+has Haiku 4.5 judge every assertion (pass/fail + reason). This script is the
+deterministic engine around that: it discovers and validates the eval files, emits the
+work-list the skill grades, and renders the per-assertion scorecard from the graded
+results. No model calls happen here, so it runs anywhere (CI included) with zero deps.
+
+Subcommands:
+  validate [SELECTOR]            Structurally validate eval files; non-zero exit on error.
+  plan     [SELECTOR] [--json]   Emit the case/assertion work-list for the /eval skill.
+  score    --results FILE [--json]
+                                 Render a per-assertion pass/fail scorecard from graded
+                                 results; non-zero exit if any assertion failed.
+
+SELECTOR (default --all):
+  --module SLUG        one module
+  --all                every module that ships evals
+  --changed [BASE]     modules changed vs BASE (default origin/main) — for per-PR CI
+
+Results file (for `score`) is JSON: a list of
+  {"module": str, "case_id": int, "assertion": str, "passed": bool, "reason": str}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MODULES_DIR = REPO / "modules"
+
+
+# ── discovery ────────────────────────────────────────────────────────────────
+
+def eval_path(slug: str) -> Path:
+    return MODULES_DIR / slug / "evals" / "evals.json"
+
+
+def modules_with_evals() -> list[str]:
+    return sorted(p.parent.parent.name for p in MODULES_DIR.glob("*/evals/evals.json"))
+
+
+def changed_modules(base: str) -> list[str]:
+    """Slugs under modules/ touched vs BASE that ship evals."""
+    r = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        cwd=REPO, capture_output=True, text=True, check=False,
+    )
+    if r.returncode != 0:  # base ref unavailable (shallow clone, fork) → fall back to all
+        sys.stderr.write(f"note: `git diff {base}...HEAD` failed; scanning all modules\n")
+        return modules_with_evals()
+    touched = set()
+    for line in r.stdout.splitlines():
+        parts = line.split("/")
+        if len(parts) >= 2 and parts[0] == "modules":
+            touched.add(parts[1])
+    have = set(modules_with_evals())
+    return sorted(touched & have)
+
+
+def select(args) -> list[str]:
+    if args.module:
+        return [args.module]
+    if args.changed is not None:
+        return changed_modules(args.changed or "origin/main")
+    return modules_with_evals()
+
+
+# ── load + validate ──────────────────────────────────────────────────────────
+
+def load_evals(slug: str) -> tuple[dict | None, list[str]]:
+    """Return (data, errors). data is None when the file is missing/unparseable."""
+    path = eval_path(slug)
+    if not path.exists():
+        return None, [f"{slug}: no evals/evals.json"]
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        return None, [f"{slug}: invalid JSON — {e}"]
+
+    errors: list[str] = []
+    if data.get("skill_name") and data["skill_name"] != slug:
+        errors.append(f"{slug}: skill_name '{data['skill_name']}' != directory '{slug}'")
+    cases = data.get("evals")
+    if not isinstance(cases, list) or not cases:
+        errors.append(f"{slug}: 'evals' must be a non-empty list")
+        return data, errors
+    seen_ids: set = set()
+    for i, case in enumerate(cases):
+        where = f"{slug} case[{i}]"
+        cid = case.get("id")
+        if cid is None:
+            errors.append(f"{where}: missing id")
+        elif cid in seen_ids:
+            errors.append(f"{where}: duplicate id {cid}")
+        else:
+            seen_ids.add(cid)
+        if not str(case.get("prompt", "")).strip():
+            errors.append(f"{where}: empty prompt")
+        assertions = case.get("assertions")
+        if not isinstance(assertions, list) or not assertions:
+            errors.append(f"{where}: needs a non-empty assertions list")
+    return data, errors
+
+
+# ── subcommands ──────────────────────────────────────────────────────────────
+
+def cmd_validate(args) -> int:
+    slugs = select(args)
+    if not slugs:
+        print("validate: no modules selected (nothing changed?) — ok")
+        return 0
+    all_errors: list[str] = []
+    total_cases = total_assertions = 0
+    for slug in slugs:
+        data, errors = load_evals(slug)
+        all_errors += errors
+        if data and isinstance(data.get("evals"), list):
+            cases = data["evals"]
+            total_cases += len(cases)
+            total_assertions += sum(len(c.get("assertions", []) or []) for c in cases)
+    print(f"validated {len(slugs)} module(s): {total_cases} cases, {total_assertions} assertions")
+    if all_errors:
+        for e in all_errors:
+            sys.stderr.write(f"  ✗ {e}\n")
+        sys.stderr.write(f"\neval-harness validate: {len(all_errors)} error(s)\n")
+        return 1
+    print("eval-harness validate: all eval files well-formed ✓")
+    return 0
+
+
+def build_plan(slugs: list[str]) -> dict:
+    modules = []
+    for slug in slugs:
+        data, _ = load_evals(slug)
+        if not data:
+            continue
+        cases = [
+            {
+                "id": c.get("id"),
+                "prompt": c.get("prompt", ""),
+                "expected_output": c.get("expected_output", ""),
+                "assertions": list(c.get("assertions", []) or []),
+                "files": list(c.get("files", []) or []),
+            }
+            for c in data.get("evals", [])
+        ]
+        modules.append({"module": slug, "cases": cases})
+    return {"modules": modules}
+
+
+def cmd_plan(args) -> int:
+    plan = build_plan(select(args))
+    if args.json:
+        print(json.dumps(plan, indent=2))
+        return 0
+    for m in plan["modules"]:
+        print(f"\n### {m['module']} — {len(m['cases'])} case(s)")
+        for c in m["cases"]:
+            print(f"  [{c['id']}] {c['prompt'][:90]}")
+            for a in c["assertions"]:
+                print(f"        - {a}")
+    if not plan["modules"]:
+        print("(no modules selected)")
+    return 0
+
+
+def cmd_score(args) -> int:
+    results = json.loads(Path(args.results).read_text())
+    if not isinstance(results, list):
+        sys.stderr.write("score: results file must be a JSON list\n")
+        return 2
+
+    # group: module -> case_id -> [rows]
+    grouped: dict = {}
+    for r in results:
+        grouped.setdefault(r.get("module", "?"), {}).setdefault(r.get("case_id"), []).append(r)
+
+    if args.json:
+        passed = sum(1 for r in results if r.get("passed"))
+        print(json.dumps({
+            "total": len(results), "passed": passed, "failed": len(results) - passed,
+            "results": results,
+        }, indent=2))
+        return 0 if passed == len(results) else 1
+
+    total = passed = 0
+    for module in sorted(grouped):
+        print(f"\n=== {module} ===")
+        for case_id in sorted(grouped[module], key=lambda x: (x is None, x)):
+            rows = grouped[module][case_id]
+            n_pass = sum(1 for r in rows if r.get("passed"))
+            print(f"  case {case_id}: {n_pass}/{len(rows)} assertions passed")
+            for r in rows:
+                mark = "✓" if r.get("passed") else "✗"
+                line = f"    {mark} {r.get('assertion', '')}"
+                if not r.get("passed") and r.get("reason"):
+                    line += f" — {r['reason']}"
+                print(line)
+            total += len(rows)
+            passed += n_pass
+    print(f"\nscorecard: {passed}/{total} assertions passed across {len(grouped)} module(s)")
+    return 0 if passed == total else 1
+
+
+def add_selector(p: argparse.ArgumentParser) -> None:
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--module", help="single module slug")
+    g.add_argument("--all", action="store_true", help="every module with evals (default)")
+    g.add_argument("--changed", nargs="?", const="origin/main", default=None,
+                   metavar="BASE", help="modules changed vs BASE (default origin/main)")
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="100x-dev eval harness")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pv = sub.add_parser("validate", help="structurally validate eval files")
+    add_selector(pv)
+    pv.set_defaults(func=cmd_validate)
+
+    pp = sub.add_parser("plan", help="emit the case/assertion work-list")
+    add_selector(pp)
+    pp.add_argument("--json", action="store_true")
+    pp.set_defaults(func=cmd_plan)
+
+    ps = sub.add_parser("score", help="render a scorecard from graded results")
+    ps.add_argument("--results", required=True)
+    ps.add_argument("--json", action="store_true")
+    ps.set_defaults(func=cmd_score)
+
+    args = ap.parse_args(argv[1:])
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/trigger-overlap-allow.txt
+++ b/scripts/trigger-overlap-allow.txt
@@ -1,0 +1,52 @@
+# Known + accepted trigger-overlap pairs (issue #24).
+# Format: slugA <-> slugB  (one pair per line; '#' starts a comment).
+# These overlaps are intentional and already disambiguated via cross-references
+# in each skill's description. The lint still REPORTS them; --strict only fails
+# on pairs NOT listed here (a genuinely new overlap). Regenerate the baseline with:
+#   python3 scripts/trigger-overlap.py --json | python3 -c "import json,sys;[print(a+' <-> '+b) for a,b in (f['pair'] for f in json.load(sys.stdin)['flagged'])]"
+#
+# --- lifecycle / quality clusters (shared gate→commit→push→launch vocabulary) ---
+launch <-> release
+commit <-> gate
+enterprise-design <-> systems-architect
+commit <-> push
+gate <-> push
+page-cro <-> signup-flow-cro
+form-cro <-> signup-flow-cro
+form-cro <-> page-cro
+ad-creative <-> paid-ads
+onboarding-cro <-> signup-flow-cro
+paywall-upgrade-cro <-> pricing-strategy
+grill-me <-> pr
+schema-markup <-> seo-audit
+data-query <-> db
+docs <-> lint
+lint <-> security
+onboarding-cro <-> page-cro
+branch <-> paywall-upgrade-cro
+email-sequence <-> revops
+competitor-alternatives <-> sales-enablement
+paid-ads <-> social-content
+ai-seo <-> schema-markup
+page-cro <-> popup-cro
+cold-email <-> revops
+conversion-copy <-> figma-translator
+copywriting <-> page-cro
+ai-seo <-> site-architecture
+popup-cro <-> signup-flow-cro
+ab-test-setup <-> analytics-tracking
+context-dump <-> pr
+issue <-> pr
+cold-email <-> email-sequence
+conversion-copy <-> enterprise-design
+form-cro <-> onboarding-cro
+form-cro <-> popup-cro
+ai-seo <-> seo-audit
+interaction-engineer <-> systems-architect
+content-strategy <-> social-content
+db <-> revops
+lint <-> test
+seo-audit <-> site-architecture
+competitor-alternatives <-> programmatic-seo
+copy-editing <-> copywriting
+conversion-copy <-> copywriting

--- a/scripts/trigger-overlap.py
+++ b/scripts/trigger-overlap.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Deterministic trigger-overlap lint (issue #24).
+
+Skills auto-trigger off their `description`. When two descriptions share too much
+trigger vocabulary, the wrong skill fires. This catches that without an LLM: it builds a
+trigger-token set per module (significant words + quoted trigger phrases), scores every
+pair by an overlap coefficient, and flags pairs at/over a threshold.
+
+Known-and-accepted overlaps (the CRO family, the lifecycle cluster, etc.) live in
+scripts/trigger-overlap-allow.txt so they're acknowledged, not noise. The lint still
+*reports* every flagged pair; `--strict` exits non-zero only on pairs that are NOT
+allow-listed — i.e. new overlaps a change just introduced.
+
+Usage:
+  python3 scripts/trigger-overlap.py [--threshold 0.14] [--strict] [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from itertools import combinations
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MODULES_DIR = REPO / "modules"
+ALLOW_FILE = Path(__file__).resolve().parent / "trigger-overlap-allow.txt"
+
+# Common English + cross-cutting skill words that carry no triggering signal.
+STOPWORDS = {
+    "the", "and", "for", "with", "use", "uses", "user", "users", "when", "wants", "want",
+    "also", "this", "that", "your", "you", "from", "into", "about", "what", "which", "should",
+    "mentions", "see", "whenever", "someone", "needs", "need", "help", "helps", "their", "them",
+    "they", "have", "has", "are", "not", "but", "any", "all", "one", "two", "three", "four",
+    "five", "more", "than", "just", "like", "isn", "won", "doesn", "don", "how", "why", "who",
+    "where", "these", "those", "some", "each", "per", "via", "out", "set", "get", "make", "run",
+    "running", "using", "based", "across", "every", "most", "much", "many", "such", "etc",
+    "page", "pages", "work", "working", "thing", "things", "way", "ways", "good", "better",
+    "best", "new", "now", "after", "before", "over", "under", "between",
+}
+WORD_RE = re.compile(r"[a-z][a-z0-9-]{2,}")
+QUOTE_RE = re.compile(r"['\"]([^'\"]{3,40})['\"]")
+
+
+def split_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        return {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    fm: dict[str, str] = {}
+    current = None
+    for line in text[4:end].splitlines():
+        if not line.strip():
+            continue
+        if line.startswith(" ") and current:
+            fm[current] = (fm[current] + " " + line.strip()).strip()
+        elif ":" in line:
+            k, _, v = line.partition(":")
+            current = k.strip()
+            fm[current] = v.strip()
+    return fm
+
+
+def trigger_tokens(description: str) -> tuple[set, set]:
+    """(word tokens, quoted trigger phrases) — both lowercased, stopwords removed."""
+    desc = description.lower()
+    phrases = {p.strip() for p in QUOTE_RE.findall(desc) if p.strip()}
+    words = {w for w in WORD_RE.findall(desc) if w not in STOPWORDS}
+    # fold quoted phrases' own words into the word set too
+    for p in phrases:
+        words |= {w for w in WORD_RE.findall(p) if w not in STOPWORDS}
+    return words, phrases
+
+
+def overlap_score(a: tuple[set, set], b: tuple[set, set]) -> float:
+    """Overlap coefficient (|A∩B| / min(|A|,|B|)) blended with a quoted-phrase bonus.
+
+    Overlap coefficient — not Jaccard — because trigger descriptions vary wildly in
+    length; we care whether the *smaller* skill's triggers largely fall inside the
+    other's, which is exactly when the wrong skill fires."""
+    wa, pa = a
+    wb, pb = b
+    if not wa or not wb:
+        return 0.0
+    word = len(wa & wb) / min(len(wa), len(wb))
+    phrase = (len(pa & pb) / min(len(pa), len(pb))) if (pa and pb) else 0.0
+    return round(0.75 * word + 0.25 * phrase, 4)
+
+
+def load_allow() -> set:
+    pairs = set()
+    if ALLOW_FILE.exists():
+        for line in ALLOW_FILE.read_text().splitlines():
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            parts = re.split(r"\s*(?:<->|,|\s)\s*", line)
+            parts = [p for p in parts if p]
+            if len(parts) == 2:
+                pairs.add(tuple(sorted(parts)))
+    return pairs
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="trigger-overlap lint")
+    ap.add_argument("--threshold", type=float, default=0.14,
+                    help="flag module pairs scoring at/above this (default 0.14)")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero on flagged pairs that are NOT allow-listed")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv[1:])
+
+    tokens = {}
+    for sf in sorted(MODULES_DIR.glob("*/SKILL.md")):
+        fm = split_frontmatter(sf.read_text())
+        desc = fm.get("description", "")
+        if desc:
+            tokens[sf.parent.name] = trigger_tokens(desc)
+
+    allow = load_allow()
+    flagged = []
+    for a, b in combinations(sorted(tokens), 2):
+        score = overlap_score(tokens[a], tokens[b])
+        if score >= args.threshold:
+            flagged.append({
+                "pair": [a, b],
+                "score": score,
+                "allowed": tuple(sorted((a, b))) in allow,
+            })
+    flagged.sort(key=lambda f: f["score"], reverse=True)
+    unallowed = [f for f in flagged if not f["allowed"]]
+
+    if args.json:
+        print(json.dumps({"threshold": args.threshold, "flagged": flagged}, indent=2))
+    else:
+        print(f"trigger-overlap: {len(flagged)} pair(s) ≥ {args.threshold} "
+              f"({len(flagged) - len(unallowed)} allow-listed, {len(unallowed)} new)\n")
+        for f in flagged:
+            tag = "  (allow-listed)" if f["allowed"] else "  ⚠ NEW"
+            print(f"  {f['score']:.3f}  {f['pair'][0]} ⇄ {f['pair'][1]}{tag}")
+        if unallowed and not args.strict:
+            print("\n  Add intended overlaps to scripts/trigger-overlap-allow.txt, "
+                  "or differentiate the descriptions.")
+
+    if args.strict and unallowed:
+        sys.stderr.write(f"\ntrigger-overlap: {len(unallowed)} new overlapping pair(s) "
+                         f"not in the allow-list\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/eval-harness.test.js
+++ b/test/eval-harness.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+// Verifies scripts/eval-harness.py (issue #24):
+//   - validate passes on the real repo's 32 eval files
+//   - validate fails on a malformed eval file
+//   - plan --json emits the case/assertion work-list
+//   - score renders a per-assertion pass/fail scorecard and exits non-zero on a failure
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const REPO = path.resolve(__dirname, '..')
+const SCRIPT = path.join(REPO, 'scripts', 'eval-harness.py')
+
+function run(args, opts = {}) {
+  return spawnSync('python3', [SCRIPT, ...args], { cwd: REPO, encoding: 'utf8', ...opts })
+}
+
+test('validate --all passes on the real repo', () => {
+  const r = run(['validate', '--all'])
+  assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`)
+  assert.match(r.stdout, /all eval files well-formed/)
+  assert.match(r.stdout, /32 module\(s\)/)
+})
+
+test('validate --module reports cases and assertions', () => {
+  const r = run(['validate', '--module', 'marketing-psychology'])
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /validated 1 module\(s\)/)
+})
+
+test('plan --json emits cases with assertions', () => {
+  const r = run(['plan', '--module', 'marketing-psychology', '--json'])
+  assert.equal(r.status, 0, r.stderr)
+  const plan = JSON.parse(r.stdout)
+  assert.equal(plan.modules.length, 1)
+  const m = plan.modules[0]
+  assert.equal(m.module, 'marketing-psychology')
+  assert.ok(m.cases.length >= 1)
+  assert.ok(Array.isArray(m.cases[0].assertions) && m.cases[0].assertions.length >= 1)
+  assert.ok(typeof m.cases[0].prompt === 'string' && m.cases[0].prompt.length > 0)
+})
+
+test('validate fails on a malformed eval file', () => {
+  // run the harness against a throwaway repo layout via a temp module dir is overkill;
+  // instead point validate at a slug whose evals.json we corrupt in a temp copy.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '100x-eval-'))
+  const modDir = path.join(tmp, 'modules', 'broken', 'evals')
+  fs.mkdirSync(modDir, { recursive: true })
+  fs.writeFileSync(path.join(modDir, 'evals.json'), '{ not json')
+  // Copy the harness so REPO resolves to our temp tree (parents[1] of scripts/).
+  fs.mkdirSync(path.join(tmp, 'scripts'))
+  fs.copyFileSync(SCRIPT, path.join(tmp, 'scripts', 'eval-harness.py'))
+  const r = spawnSync('python3', [path.join(tmp, 'scripts', 'eval-harness.py'), 'validate', '--module', 'broken'],
+    { cwd: tmp, encoding: 'utf8' })
+  assert.equal(r.status, 1, 'malformed eval file must fail validation')
+  assert.match(r.stderr, /invalid JSON/)
+})
+
+test('score renders a pass/fail scorecard and exits non-zero on failure', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '100x-score-'))
+  const results = path.join(tmp, 'results.json')
+  fs.writeFileSync(results, JSON.stringify([
+    { module: 'demo', case_id: 1, assertion: 'does the thing', passed: true, reason: '' },
+    { module: 'demo', case_id: 1, assertion: 'handles the edge case', passed: false, reason: 'ignored empty input' },
+  ]))
+  const r = run(['score', '--results', results])
+  assert.equal(r.status, 1, 'a failed assertion must make score exit non-zero')
+  assert.match(r.stdout, /✓ does the thing/)
+  assert.match(r.stdout, /✗ handles the edge case — ignored empty input/)
+  assert.match(r.stdout, /1\/2 assertions passed/)
+})
+
+test('score exits zero when every assertion passes', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '100x-score-'))
+  const results = path.join(tmp, 'results.json')
+  fs.writeFileSync(results, JSON.stringify([
+    { module: 'demo', case_id: 1, assertion: 'a', passed: true, reason: '' },
+  ]))
+  const r = run(['score', '--results', results])
+  assert.equal(r.status, 0, r.stderr)
+})

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,195 @@
+'use strict'
+
+// Verifies the first-party enforcing hooks (issue #22):
+//   - secret-scan blocks obvious credentials, allows placeholders
+//   - gate-on-commit blocks until /gate records a pass, and re-arms when the tree changes
+//   - permission-router auto-approves read-only commands, defers on risky ones
+//   - emit-hooks merges idempotently, honours per-hook toggles, and --sync never enables
+//     a hook the user opted out of
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const REPO = path.resolve(__dirname, '..')
+const HOOKS = path.join(REPO, 'hooks')
+const MODULES_PY = path.join(REPO, 'adapters', 'lib', 'modules.py')
+
+function runHook(script, event, opts = {}) {
+  return spawnSync('python3', [path.join(HOOKS, script)], {
+    input: JSON.stringify(event),
+    encoding: 'utf8',
+    ...opts,
+  })
+}
+
+function git(args, cwd) {
+  return spawnSync('git', args, { cwd, encoding: 'utf8' })
+}
+
+function tmpGitRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '100x-gate-'))
+  git(['init', '-q'], dir)
+  git(['config', 'user.email', 't@t.co'], dir)
+  git(['config', 'user.name', 'tester'], dir)
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'hello\n')
+  git(['add', '-A'], dir)
+  git(['commit', '-qm', 'init'], dir)
+  return dir
+}
+
+// ── secret-scan ───────────────────────────────────────────────────────────────
+
+test('secret-scan blocks an obvious AWS key', () => {
+  const r = runHook('pretooluse-secret-scan.py', {
+    tool_name: 'Write',
+    tool_input: { file_path: 'config.py', content: 'KEY = "AKIAIOSFODNN7EXAMPLE"' },
+  })
+  assert.equal(r.status, 2, r.stderr)
+  assert.match(r.stderr, /AWS access key/)
+})
+
+test('secret-scan blocks an OpenAI-style key', () => {
+  const r = runHook('pretooluse-secret-scan.py', {
+    tool_name: 'Edit',
+    tool_input: { file_path: 'a.py', new_string: 'k="sk-abcdefghijklmnopqrstuvwxyz0123"' },
+  })
+  assert.equal(r.status, 2, r.stderr)
+})
+
+test('secret-scan allows placeholders / env indirection', () => {
+  const r = runHook('pretooluse-secret-scan.py', {
+    tool_name: 'Write',
+    tool_input: { file_path: '.env.example', content: 'API_KEY=your_api_key_here\nT=${TOKEN}' },
+  })
+  assert.equal(r.status, 0, r.stderr)
+})
+
+test('secret-scan can be disabled with HOOK_SECRET_SCAN=off', () => {
+  const r = runHook('pretooluse-secret-scan.py', {
+    tool_name: 'Write',
+    tool_input: { file_path: 'config.py', content: 'KEY = "AKIAIOSFODNN7EXAMPLE"' },
+  }, { env: { ...process.env, HOOK_SECRET_SCAN: 'off' } })
+  assert.equal(r.status, 0, r.stderr)
+})
+
+// ── gate-on-commit ──────────────────────────────────────────────────────────
+
+test('gate hook blocks commit with no pass, allows after gate-pass, re-arms on edit', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), '100x-home-'))
+  const repo = tmpGitRepo()
+  const env = { ...process.env, HOME: home }
+  const commitEvent = { tool_name: 'Bash', cwd: repo, tool_input: { command: 'git commit -m wip' } }
+
+  // 1. no recorded pass → blocked
+  let r = runHook('pretooluse-gate.py', commitEvent, { env })
+  assert.equal(r.status, 2, 'expected block before any gate pass')
+
+  // 2. record a pass → allowed
+  const pass = spawnSync('python3', [path.join(HOOKS, 'gate-pass.py'), repo], { env, encoding: 'utf8' })
+  assert.equal(pass.status, 0, pass.stderr)
+  r = runHook('pretooluse-gate.py', commitEvent, { env })
+  assert.equal(r.status, 0, `expected allow after gate pass:\n${r.stderr}`)
+
+  // 3. push is gated the same way → still allowed for the unchanged tree
+  r = runHook('pretooluse-gate.py', { tool_name: 'Bash', cwd: repo, tool_input: { command: 'git push origin main' } }, { env })
+  assert.equal(r.status, 0, r.stderr)
+
+  // 4. edit the tree → cache invalid → blocked again
+  fs.appendFileSync(path.join(repo, 'a.txt'), 'changed\n')
+  r = runHook('pretooluse-gate.py', { tool_name: 'Bash', cwd: repo, tool_input: { command: 'git commit -am wip' } }, { env })
+  assert.equal(r.status, 2, 'expected re-armed block after a tree change')
+})
+
+test('gate hook ignores non-commit git commands and non-git dirs', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), '100x-home-'))
+  const repo = tmpGitRepo()
+  const env = { ...process.env, HOME: home }
+  let r = runHook('pretooluse-gate.py', { tool_name: 'Bash', cwd: repo, tool_input: { command: 'git status' } }, { env })
+  assert.equal(r.status, 0, 'git status must not be gated')
+
+  const nongit = fs.mkdtempSync(path.join(os.tmpdir(), '100x-nogit-'))
+  r = runHook('pretooluse-gate.py', { tool_name: 'Bash', cwd: nongit, tool_input: { command: 'git commit -m x' } }, { env })
+  assert.equal(r.status, 0, 'commit outside a git repo must not be gated')
+})
+
+// ── permission-router ─────────────────────────────────────────────────────────
+
+test('router auto-approves a read-only command', () => {
+  const r = runHook('permission-router.py', { tool_name: 'Bash', tool_input: { command: 'ls -la && cat README.md' } })
+  assert.equal(r.status, 0, r.stderr)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.hookSpecificOutput.permissionDecision, 'allow')
+})
+
+test('router defers (no decision) on a risky command', () => {
+  const r = runHook('permission-router.py', { tool_name: 'Bash', tool_input: { command: 'rm -rf build' } })
+  assert.equal(r.status, 0)
+  assert.equal(r.stdout.trim(), '', 'risky command should not be auto-approved')
+})
+
+// ── emit-hooks merge ──────────────────────────────────────────────────────────
+
+function emitHooks(settingsFile, extraEnv = {}, args = []) {
+  return spawnSync('python3', [MODULES_PY, 'emit-hooks', ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, SETTINGS_FILE: settingsFile, ...extraEnv },
+  })
+}
+
+function readSettings(f) {
+  return JSON.parse(fs.readFileSync(f, 'utf8'))
+}
+
+function commandCount(settings, needle) {
+  let n = 0
+  for (const arr of Object.values(settings.hooks || {})) {
+    for (const entry of arr) for (const h of entry.hooks || []) {
+      if ((h.command || '').includes(needle)) n++
+    }
+  }
+  return n
+}
+
+test('emit-hooks is idempotent and preserves user hooks', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '100x-set-'))
+  const f = path.join(dir, 'settings.json')
+  fs.writeFileSync(f, JSON.stringify({
+    hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo mine' }] }] },
+  }))
+  emitHooks(f)
+  emitHooks(f) // run twice
+  const s = readSettings(f)
+  assert.equal(commandCount(s, 'pretooluse-gate.py'), 1, 'gate hook must appear exactly once')
+  assert.equal(commandCount(s, 'pretooluse-secret-scan.py'), 1, 'secret-scan on by default')
+  assert.equal(commandCount(s, 'echo mine'), 1, "user's own hook must be preserved")
+})
+
+test('emit-hooks toggles add/remove declaratively', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '100x-set-'))
+  const f = path.join(dir, 'settings.json')
+  fs.writeFileSync(f, '{}')
+  emitHooks(f, { HOOK_ROUTER: '1', HOOK_SECRET: '0' })
+  let s = readSettings(f)
+  assert.equal(commandCount(s, 'permission-router.py'), 1, 'router enabled by toggle')
+  assert.equal(commandCount(s, 'pretooluse-secret-scan.py'), 0, 'secret disabled by toggle')
+
+  // flip secret back on, router off → declarative
+  emitHooks(f, { HOOK_ROUTER: '0', HOOK_SECRET: '1' })
+  s = readSettings(f)
+  assert.equal(commandCount(s, 'permission-router.py'), 0)
+  assert.equal(commandCount(s, 'pretooluse-secret-scan.py'), 1)
+})
+
+test('emit-hooks --sync only refreshes already-present hooks', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '100x-set-'))
+  const f = path.join(dir, 'settings.json')
+  fs.writeFileSync(f, '{}')
+  // sync against empty settings must NOT add the (off-by-default) lint hook, even if toggled on
+  emitHooks(f, { HOOK_LINT: '1' }, ['--sync'])
+  const s = readSettings(f)
+  assert.equal(commandCount(s, 'posttooluse-lint.py'), 0, 'sync must not enable an absent hook')
+})

--- a/test/trigger-overlap.test.js
+++ b/test/trigger-overlap.test.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Verifies scripts/trigger-overlap.py (issue #24):
+//   - flags the known overlapping pairs named in the issue
+//   - --strict passes on the current repo (every flagged pair is allow-listed)
+//   - --strict fails when an allow-listed pair is removed (i.e. a "new" overlap appears)
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const REPO = path.resolve(__dirname, '..')
+const SCRIPT = path.join(REPO, 'scripts', 'trigger-overlap.py')
+const ALLOW = path.join(REPO, 'scripts', 'trigger-overlap-allow.txt')
+
+function run(args = [], opts = {}) {
+  return spawnSync('python3', [SCRIPT, ...args], { cwd: REPO, encoding: 'utf8', ...opts })
+}
+
+function flaggedPairs() {
+  const r = run(['--json'])
+  assert.equal(r.status, 0, r.stderr)
+  return JSON.parse(r.stdout).flagged.map((f) => f.pair.slice().sort().join(' <-> '))
+}
+
+test('flags the known overlapping pairs from the issue', () => {
+  const pairs = new Set(flaggedPairs())
+  for (const pair of [
+    ['conversion-copy', 'copywriting'],
+    ['enterprise-design', 'systems-architect'],
+    ['form-cro', 'signup-flow-cro'],
+    ['onboarding-cro', 'signup-flow-cro'],
+  ]) {
+    assert.ok(pairs.has(pair.slice().sort().join(' <-> ')), `expected to flag ${pair.join(' ⇄ ')}`)
+  }
+})
+
+test('--strict passes on the current repo (all flagged pairs allow-listed)', () => {
+  const r = run(['--strict'])
+  assert.equal(r.status, 0, `expected 0 new overlaps:\n${r.stdout}\n${r.stderr}`)
+  assert.match(r.stdout, /0 new/)
+})
+
+test('--strict fails when a previously-accepted overlap is no longer allow-listed', () => {
+  // Copy repo descriptions are stable; simulate a "new" overlap by running with an
+  // empty allow-list via a temp copy of the script pointing at an empty allow file.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), '100x-overlap-'))
+  fs.mkdirSync(path.join(tmp, 'scripts'))
+  // Point the script's ALLOW_FILE at an empty file by copying it beside an empty allow.
+  let src = fs.readFileSync(SCRIPT, 'utf8')
+  fs.writeFileSync(path.join(tmp, 'scripts', 'trigger-overlap-allow.txt'), '# empty\n')
+  fs.writeFileSync(path.join(tmp, 'scripts', 'trigger-overlap.py'), src)
+  // Symlink modules/ so the temp script sees the real descriptions (REPO = parents[1]).
+  fs.symlinkSync(path.join(REPO, 'modules'), path.join(tmp, 'modules'))
+  const r = spawnSync('python3', [path.join(tmp, 'scripts', 'trigger-overlap.py'), '--strict'],
+    { cwd: tmp, encoding: 'utf8' })
+  assert.equal(r.status, 1, 'an empty allow-list must surface the existing overlaps as new')
+  assert.match(r.stderr, /new overlapping pair/)
+})
+
+test('allow-list file exists and lists the named pairs', () => {
+  const allow = fs.readFileSync(ALLOW, 'utf8')
+  assert.match(allow, /conversion-copy <-> copywriting/)
+  assert.match(allow, /enterprise-design <-> systems-architect/)
+})

--- a/update.sh
+++ b/update.sh
@@ -55,6 +55,14 @@ run_plugin_updates() {
   fi
 }
 
+# ── Hook sync (only refreshes hooks already installed; never enables new ones) ─
+# Keeps the wired-in hook commands current after a pull without re-prompting or
+# silently opting users into hooks they declined at install time.
+sync_hooks() {
+  [ -f "$SETTINGS_FILE" ] || return 0
+  python3 "$REPO_DIR/adapters/lib/modules.py" emit-hooks --sync 2>/dev/null || true
+}
+
 if [ "$PLUGINS_ONLY" = true ]; then
   echo ""
   echo "Updating Claude plugins..."
@@ -112,6 +120,7 @@ if added > 0:
 else:
     print('  Plugins: settings already up to date ✓')
 PYEOF
+  sync_hooks
   run_plugin_updates
   echo ""
   echo -e "${CYAN}Tip: Run /reload-plugins in Claude Code to activate any plugin changes.${NC}"
@@ -226,6 +235,9 @@ else:
 PYEOF
 
 echo -e "  ${CYAN}→ Shell aliases auto-updated (sourced file)${NC}"
+
+# Refresh any installed hooks so their wired commands stay current.
+sync_hooks
 
 # ── Update Claude plugins ─────────────────────────────────────────────────────
 run_plugin_updates


### PR DESCRIPTION
Implements two P0s from the power-up review. **Closes #22, closes #24.**

## #22 — First-party enforcing hooks
Turns "nothing ships without passing the gate" from prose into enforcement. Opt-in; nothing changes unless you enable it.

- **`hooks/`** — plain `python3`, zero deps, driven by `hooks/hooks.manifest.json` (single source of truth):
  - `pretooluse-gate.py` — blocks `git commit`/`git push` unless `/gate` recorded a pass for the **current tree**.
  - `pretooluse-secret-scan.py` — blocks writes containing obvious credentials (AWS/OpenAI/GitHub/Slack/Google/Stripe keys, private-key blocks, high-entropy assignments); skips placeholders.
  - `posttooluse-lint.py` (advisory) and `permission-router.py` (auto-approve read-only Bash; optional model escalation) ship **off** by default.
  - `gate-pass.py` records the pass.
- **`adapters/lib/modules.py emit-hooks [--sync]`** — idempotent, declarative merge into `~/.claude/settings.json` (same pattern as the plugin merge). Per-hook toggles: `HOOK_GATE`/`HOOK_SECRET`/`HOOK_LINT`/`HOOK_ROUTER`. Flipping a toggle off removes the hook; re-running never duplicates. `--sync` only refreshes hooks already present.
- **`install.sh`** — new opt-in *Hooks* component + per-hook selection menu. **`update.sh`** refreshes installed hooks.
- **Gate-cache fix (the spec tied this to #22):** cache is re-keyed on a **tree token** (HEAD + tracked diff + untracked status), closing the stale-cache-for-a-dirty-tree / post-rebase hole. `gate` + `commit` skills record/check via `gate-pass.py`.
- **`subagents` skill** — points at the real `permission-router.py` artifact (was prose), fixes the stale `code.claude.com/docs` URL, marks `ctrl+b` Claude-Code-specific.

**Acceptance:** ✅ commit blocked when gate hasn't passed for HEAD · ✅ obvious API key blocked · ✅ idempotent merge (no dupes on re-run) · ✅ subagents references a real artifact.

## #24 — Eval harness + trigger-overlap lint
Wires up the 32 dormant `evals.json`.

- **`scripts/eval-harness.py`** — `validate` / `plan` / `score` with `--module`/`--all`/`--changed`. Renders a **per-assertion pass/fail scorecard**. No model calls (runs in CI anywhere).
- **`modules/eval/` (`/eval`)** — fans eval cases out to parallel subagents and has **Haiku 4.5 grade each assertion** with structured output, then renders the scorecard. (This is the grading half; the script is the deterministic engine.)
- **`scripts/trigger-overlap.py` + `trigger-overlap-allow.txt`** — deterministic overlap lint (overlap coefficient over description trigger tokens). Flags the known pairs (CRO family, `conversion-copy⇄copywriting`, `systems-architect⇄enterprise-design`); `--strict` fails only on **new** overlaps.
- **`.github/workflows/evals.yml`** — separate from `meta.yml` and the `github-actions/ci.yml` template: trigger-overlap `--strict` on every PR, changed-module eval validation + inventory **posted to the PR**, nightly full sweep.
- README counts → **65 modules / 26 slash commands / 39 auto-trigger skills**.

**Acceptance:** ✅ harness produces a per-assertion scorecard · ✅ CI runs evals on changed modules and posts results · ✅ trigger-overlap flags the known pairs.

## Verification
- `node --test test/*.test.js` → **46/46 pass** (incl. new `hooks` / `eval-harness` / `trigger-overlap` suites)
- `python3 scripts/meta-check.py` → pass (65/26/39/12, version triple OK)
- `python3 scripts/trigger-overlap.py --strict` → 0 new overlaps
- `bash -n install.sh && bash -n update.sh` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)
