### PR TITLE
feat: Workflow/subagent fan-out for orchestrate, gate, test, launch (#25)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-workflow-fanout-design.md
+++ b/docs/superpowers/specs/2026-05-31-workflow-fanout-design.md
@@ -1,0 +1,75 @@
+# Design — Issue #25: Workflow/subagent fan-out for orchestrate, gate, test, launch
+
+_Source: 100x-dev power-up review (Theme 5). Priority P1 · Effort M._
+_Parent spec: `2026-05-31-100x-powerup-review-design.md`._
+
+## Problem
+
+`orchestrate`, `gate`, `test`, and `launch` run independent work serially in a single
+context — a pre-platform-feature pattern. The `Workflow` tool, parallel `Agent`/`Task`
+subagents, and structured-output return contracts now make deterministic fan-out cheap
+and auditable. The skills' own prose ("use subagents", "throw more compute at it") shows
+intent; the concrete wiring never landed.
+
+## Constraints
+
+- These skills are emitted to **7 platforms**. `Workflow`/`Agent`/`Task` are
+  Claude-Code-specific (adversarial-pass correction #4: non-Claude routing is
+  documentation-only). Guidance must degrade gracefully.
+- **No generator changes.** Pure prose edits to 5 `SKILL.md` files — keeps #25 out of
+  the per-module-emitter lane (#34).
+- The `e2e-patterns.md` broken reference (test/SKILL.md:384) is **#27's** scope, not
+  touched here.
+
+## Design
+
+### Shared convention (lands in `subagents` first)
+
+Two reusable primitives the other four skills reference rather than redefine:
+
+1. **The fan-out ladder** — one capability-gated instruction:
+   > Prefer the `Workflow` tool for deterministic, auditable fan-out. If unavailable,
+   > dispatch parallel `Agent`/`Task` subagents. If neither exists (non-Claude-Code
+   > platforms), run the phases serially in-context.
+
+2. **The structured return contract** — exploration/review/verdict subagents return a
+   fixed schema, not prose, so the parent reduces deterministically:
+   ```
+   { summary, findings[] {severity, title, file, detail}, files[], risks[], confidence }
+   ```
+   Plus: model-routing note (**Haiku for breadth/mechanical, Opus for depth/judgment**)
+   and a reframe of "Context Isolation" — with 1M context, isolate for **parallelism +
+   adversarial independence**, not token savings.
+
+### Per-skill changes
+
+- **`orchestrate`** — add a "Fan-out execution" section: plan → parallel implementation
+  subagents (one per workstream) → gather structured diffs → independent `/code-review`
+  reviewer subagent → merge/verify gate. Reference `dispatching-parallel-agents` +
+  `subagent-driven-development`. Decouple the hardcoded `docs/superpowers/plans/...`
+  path (use native plan mode / `writing-plans` output location).
+- **`gate`** — Gates 2/3/4/5 (security, build, docker, cloud-security) are mutually
+  independent → fan out as parallel subagents each returning a
+  `{gate,status,findings[],severity}` verdict, reduced into the existing summary box.
+  Gate 1 (the test loop) stays the long pole. Verdicts cache on the **tree hash**
+  (consistent with the `gate-pass.py` token, not bare HEAD).
+- **`test`** — Phase 1 unit layers (Vitest FE / Jest BE / pytest Python) are
+  independent → fan out before the shared-Docker integration phase (Phase 2), which
+  stays serial because it shares one DB.
+- **`launch`** — after the Phase 1 test gate, fan out Phase 2/3/4 (lint ‖ security ‖
+  build). Replace the prose "retry 5× / sleep 10s" health check with a bounded backoff
+  loop. Fix the gate-cache drift at line 116 (`echo HEAD > gate-cache` →
+  `gate-pass.py`) so it matches the #22 hook contract.
+
+## Acceptance criteria (from #25)
+
+- [ ] `orchestrate` documents a concrete Workflow fan-out example.
+- [ ] `gate` aggregates parallel structured verdicts rather than serial ASCII boxes.
+- [ ] `subagents` specifies a structured return schema.
+
+## Testing / verification
+
+- `python3 adapters/lib/modules.py` regen + meta-check CI must still pass (frontmatter
+  parse, counts). Run the eval harness on the 4 changed modules.
+- Manual read-through: confirm the serial fallback path is intact for non-CC platforms.
+- `/gate` before commit.

--- a/modules/gate/SKILL.md
+++ b/modules/gate/SKILL.md
@@ -14,6 +14,29 @@ slash_command: /gate
 
 ---
 
+## How to run the gates (fan out the independent ones)
+
+Gate 1 (the coverage loop) is the long pole — run it first and let it finish. Gates 2–5
+(**security, build, docker, cloud-security**) are mutually independent: they read the
+tree but never depend on each other's results, so **run them in parallel**, not as serial
+ASCII boxes.
+
+Use the fan-out ladder from the `subagents` skill: prefer the `Workflow` tool (one stage
+per gate, `schema`-validated return), else dispatch parallel `Agent`/`Task` subagents,
+else fall back to running them serially. Each gate subagent returns a structured verdict:
+
+```json
+{ "gate": "security", "status": "passed|failed|skipped", "severity": "critical|high|none", "findings": ["..."] }
+```
+
+The parent **reduces** the verdicts into the summary box below: any `failed` with
+critical/high severity ⇒ overall FAILED. Cache each verdict keyed on the **tree hash**
+(`git write-tree` + clean-tree check) so a re-run on an unchanged tree reuses the verdict
+instead of recomputing — the same key the `gate-pass.py` token uses (see *Record the
+pass* below). Never reuse a verdict across a changed tree.
+
+---
+
 ## Gate 1 — Test Coverage (≥ 95%)
 
 Run the **test** workflow. Run ALL test layers (unit, integration, E2E if configured).
@@ -156,6 +179,10 @@ Gate 5: Cloud Security ✅ PASSED | ❌ FAILED — do not proceed | skipped (loc
 ---
 
 ## Gate summary output
+
+This box is the **reduce step**: collect the structured verdict from each gate (Gate 1
+plus the parallel Gates 2–5) and aggregate. STATUS is PASSED only when every applicable
+gate reports `passed` with no critical/high severity.
 
 ```
 ╔══════════════════════════════════════════════════════╗

--- a/modules/launch/SKILL.md
+++ b/modules/launch/SKILL.md
@@ -79,6 +79,19 @@ Thresholds: Lines ≥ 95% | Functions ≥ 95% | Statements ≥ 95% | Branches �
 
 ---
 
+## Phases 2–4 — Lint ‖ Security ‖ Build (fan out)
+
+Phase 1 (tests) is the long pole and must pass first. **Phases 2, 3, and 4 — lint,
+security, and build — are mutually independent** (they read the tree, not each other's
+results), so run them in parallel rather than serially. Use the fan-out ladder from the
+`subagents` skill: prefer the `Workflow` tool (one stage per phase, `schema`-validated
+return), else parallel `Agent`/`Task` subagents, else run them serially.
+
+Each returns `{ phase, status, findings[] }`; **all three must report `passed`** before
+the gate-cache write below. The phase descriptions that follow define what each one does.
+
+---
+
 ## Phase 2 — Lint
 
 Run the **lint** workflow. Fix all errors across frontend, backend, and type checks.
@@ -111,10 +124,13 @@ Fix any compiler errors. Re-build only the failing target.
 
 **GATE: All applicable builds succeed with zero errors.**
 
-Phases 1–4 constitute a full gate pass. Write the gate cache so commit and push skip re-running it:
+Phases 1–4 constitute a full gate pass. Record it so the `gate-on-commit` hook and the
+commit/push workflows skip re-running the gate:
 ```bash
-echo "$(git rev-parse HEAD)" > ~/.100x-dev/gate-cache
+python3 ~/100x-dev/hooks/gate-pass.py 2>/dev/null || true
 ```
+This writes a token for the **current tree state** (HEAD + tracked diff + untracked
+files), so any later edit re-arms the gate. Only run it when all of Phases 1–4 passed.
 
 ---
 
@@ -151,9 +167,26 @@ Read health endpoint URLs from the project instruction file, README, or use comm
 # /health, /healthz, /api/health, /status
 ```
 
-Hit each endpoint. Retry up to 5 times with 10-second intervals (deployment may still be rolling out). Confirm HTTP 200 and a healthy response body.
+Hit each endpoint with a **bounded exponential backoff** loop — a fresh deploy may still
+be rolling out, so don't hammer it at a fixed interval or wait forever:
 
-**If health checks fail after 5 retries → trigger rollback (Step 4).**
+```bash
+HEALTH_URL="$1"   # resolved above
+attempt=0; max_attempts=6; delay=2
+until curl -fsS --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    echo "Health check failed after $max_attempts attempts (~$((2 ** max_attempts))s)"; exit 1
+  fi
+  echo "Health not ready (attempt $attempt/$max_attempts) — retrying in ${delay}s"
+  sleep "$delay"; delay=$((delay * 2))   # 2,4,8,16,32s — caps total wait, backs off cleanly
+done
+echo "Health OK after $attempt retr$([ "$attempt" = 1 ] && echo y || echo ies)"
+```
+
+Confirm HTTP 200 and a healthy response body.
+
+**If the loop exhausts `max_attempts` → trigger rollback (Step 4).**
 
 ### Step 2 — Smoke tests
 

--- a/modules/orchestrate/SKILL.md
+++ b/modules/orchestrate/SKILL.md
@@ -4,7 +4,7 @@ description: Apply the Workflow Orchestration methodology for complex, multi-ste
 category: engineering
 tier: core
 slash_command: /orchestrate
-allowed-tools: Bash Read Edit Write Grep Glob Agent
+allowed-tools: Bash Read Edit Write Grep Glob Agent Task Workflow
 ---
 
 # Orchestrate — Complex Task Orchestration
@@ -20,15 +20,34 @@ Apply workflow orchestration methodology for multi-step tasks with 3+ steps or a
 
 ### 1. Plan first (invoke `writing-plans` skill)
 
-**Always start by invoking the `writing-plans` skill** to produce a structured plan document at `docs/superpowers/plans/YYYY-MM-DD-<feature>.md` with TDD-style task steps. Do not proceed to coding until the plan is written and reviewed.
+**Always start by invoking the `writing-plans` skill** (or native plan mode if your platform has it) to produce a structured plan with TDD-style task steps. Write it to wherever `writing-plans` puts plans for this repo — do not assume a fixed path. Do not proceed to coding until the plan is written and reviewed.
 
 - If something goes sideways mid-task: STOP, re-plan using `writing-plans` again
 - Track progress via `tasks/todo.md` checkboxes
 
-### 2. Use subagents
+### 2. Use subagents (fan out independent work)
 - Offload research, exploration, and parallel analysis to subagents
 - Keep main context window clean and focused
 - One task per subagent for precision
+- Invoke the `subagents` skill for the **fan-out ladder** and **standard return contract**
+
+Once the plan splits into **independent workstreams**, do not implement them serially.
+Fan them out using the ladder from the `subagents` skill (Workflow tool → parallel
+subagents → serial fallback):
+
+```
+plan (writing-plans)
+  → parallel implementation subagents     # one per independent workstream, isolated
+      each returns { summary, files[], diff, risks[], confidence }
+  → gather the structured diffs
+  → independent reviewer subagent          # fresh context, runs /code-review — no self-review bias
+      returns { findings[]{severity,file,detail}, verdict }
+  → merge / verify gate                    # apply, run /gate, only then mark done
+```
+
+Reference `dispatching-parallel-agents` and `subagent-driven-development` for the
+mechanics. Use worktree isolation when subagents edit files in parallel so they don't
+collide. Workstreams that share state (same module, ordering dependency) stay serial.
 
 ### 3. Self-improvement loop
 - After any correction: note the pattern in `tasks/lessons.md`

--- a/modules/push/SKILL.md
+++ b/modules/push/SKILL.md
@@ -16,17 +16,20 @@ Quality gate re-runs before pushing. **Do NOT push if any gate fails.**
 
 ## Phase 0 — Quality Gate (MANDATORY)
 
-Check gate cache first — skip if already passed for this exact HEAD:
+Check gate cache first — skip if it already passed for this exact tree state. The cache
+is keyed on a tree token (HEAD + tracked diff + untracked files), not a bare HEAD, so a
+dirty or rebased tree never reuses a stale pass — the same token `/commit` writes and the
+`gate-on-commit` hook checks:
 
 ```bash
-HEAD=$(git rev-parse HEAD)
+TOKEN=$(python3 ~/100x-dev/hooks/gate-pass.py --print 2>/dev/null)
 CACHED=$(cat ~/.100x-dev/gate-cache 2>/dev/null)
-[ "$CACHED" = "$HEAD" ] && echo "Gate: skipped (already passed for $HEAD)" && GATE_DONE=true || GATE_DONE=false
+[ -n "$TOKEN" ] && [ "$CACHED" = "$TOKEN" ] && echo "Gate: skipped (already passed for this tree)" && GATE_DONE=true || GATE_DONE=false
 ```
 
-If `GATE_DONE=false`: run the **gate** workflow. On pass, write cache:
+If `GATE_DONE=false`: run the **gate** workflow. On pass, record it:
 ```bash
-echo "$HEAD" > ~/.100x-dev/gate-cache
+python3 ~/100x-dev/hooks/gate-pass.py
 ```
 
 Do NOT push until gate passes. If gate fails → STOP, fix, clear cache, new commit, re-run.

--- a/modules/subagents/SKILL.md
+++ b/modules/subagents/SKILL.md
@@ -3,7 +3,7 @@ name: subagents
 description: Use subagents to throw more compute at hard problems, keep the main context window clean, and auto-approve safe permissions via hooks. Use when a task is complex, exploratory, or can be parallelized across multiple independent workstreams.
 category: engineering
 tier: on-demand
-allowed-tools: Agent
+allowed-tools: Agent Task Workflow
 ---
 
 Invoke this skill when a task is complex, exploratory, or parallel in nature. Subagents keep the main context clean and focused.
@@ -29,8 +29,13 @@ use 5 subagents to explore the codebase
 
 ### B. Context Isolation
 Offload heavy research or analysis to a subagent so the main agent's context stays focused on the implementation.
-- Research → subagent → returns a summary
-- Main agent uses the summary, never sees the raw noise
+- Research → subagent → returns a structured result (see *Standard return contract* below)
+- Main agent uses the result, never sees the raw noise
+
+**Reframe for the 1M-context era:** with a 1M-token window, token savings is no longer the
+main reason to isolate. Isolate for **parallelism** (independent work running at once) and
+**adversarial independence** (a fresh subagent with zero authoring context reviews work
+without self-review bias). Treat context savings as a side benefit, not the goal.
 
 ### C. Permission Routing via Hook
 Auto-approve obviously-safe tool calls so they don't interrupt with a prompt, while
@@ -50,6 +55,52 @@ installable artifact — not just advice:
   `HOOK_ROUTER=1`.
 - See `~/100x-dev/hooks/README.md` and the hooks docs:
   <https://docs.claude.com/en/docs/claude-code/hooks>
+
+## Fan-out ladder (how to parallelize)
+
+When a skill says "fan out" or "run these in parallel", pick the highest rung your
+platform supports — they all reach the same outcome, only the determinism differs:
+
+1. **`Workflow` tool (best — Claude Code).** Use it for deterministic, auditable fan-out:
+   one stage per independent unit, structured-output return per agent, a reduce step that
+   aggregates verdicts. Phase order and concurrency caps are enforced by the runtime, not
+   by prose.
+2. **Parallel `Agent`/`Task` subagents (good).** Dispatch the independent units as
+   concurrent subagents in a single message; gather their structured returns and reduce.
+   No runtime enforcement, but real parallelism.
+3. **Serial in-context (fallback — any platform).** If neither tool exists (most
+   non-Claude-Code platforms), run the units one after another in the main context. The
+   outcome is identical; only wall-clock and isolation are lost.
+
+A fan-out site is only worth it when the units are **genuinely independent** (no shared
+mutable state, no ordering dependency). Anything that shares a resource — one Docker DB,
+one build dir — stays serial or needs isolation (worktrees).
+
+## Standard return contract
+
+Exploration / research / review / verdict subagents return a **fixed structure, not
+prose**, so the parent can reduce deterministically (sort by severity, filter by
+confidence, dedup by file):
+
+```json
+{
+  "summary":    "one-line headline of what was found",
+  "findings":   [{ "severity": "critical|high|medium|low", "title": "", "file": "path:line", "detail": "" }],
+  "files":      ["paths touched or inspected"],
+  "risks":      ["what could be wrong / what wasn't covered"],
+  "confidence": "high|medium|low"
+}
+```
+
+Skills adapt the shape to their job (e.g. `gate` subagents return
+`{gate, status, findings[], severity}`), but the principle is constant: **structured in,
+structured out**. With the `Workflow` tool, pass this as the agent's `schema` so the
+return is validated automatically.
+
+**Model routing for fan-out:** route breadth/mechanical scans (file sweeps, lint, simple
+greps) to **Haiku** for cheap concurrency; route depth/judgment (security triage,
+root-cause analysis, go/no-go verdicts) to **Opus** with extended thinking. Default
+cheap, escalate on uncertainty.
 
 ## Usage Patterns
 

--- a/modules/test/SKILL.md
+++ b/modules/test/SKILL.md
@@ -156,6 +156,13 @@ Determine which layers apply:
 
 Run smallest-scope tests first to get fast feedback.
 
+The detected unit layers (**Frontend Vitest / Backend Jest / Python pytest**) are
+independent — they run in separate processes and share no state — so **fan them out** per
+the `subagents` skill ladder (Workflow tool → parallel subagents → serial fallback)
+instead of running them one after another. Each layer returns
+`{ layer, status, passed, failed, coverage }`; the parent collects them. This is safe
+*before* Phase 2 only — the integration phase shares one Docker DB and stays serial.
+
 ### Frontend unit (Vitest):
 ```bash
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
Closes #25.

## What

Theme 5 of the power-up review: teach the four serial lifecycle skills to **fan out independent work** using the platform's `Workflow` tool / parallel subagents, with a graceful **serial fallback** for non-Claude-Code platforms (per the spec's adversarial-pass correction #4).

## Changes

**Foundation — `subagents`** (the other four reference these, not redefine):
- **Fan-out ladder** — one capability-gated instruction: `Workflow` tool → parallel `Agent`/`Task` subagents → serial in-context fallback.
- **Standard return contract** — `{summary, findings[], files[], risks[], confidence}`; structured in, structured out.
- **Model-routing note** — Haiku for breadth/mechanical, Opus for depth/judgment; default cheap, escalate on uncertainty.
- Reframed **Context Isolation** for the 1M-context era — isolate for parallelism + adversarial independence, not token savings.

**Consumers:**
- **`orchestrate`** — concrete fan-out block (plan → parallel impl subagents → structured diffs → independent `/code-review` reviewer → merge/verify gate); decoupled the hardcoded `docs/superpowers/plans/…` path.
- **`gate`** — Gates 2–5 (security/build/docker/cloud-security) run as **parallel structured verdicts** reduced into the summary box; verdicts cache on the tree hash.
- **`test`** — Phase 1 unit layers (Vitest/Jest/pytest) fan out before the shared-Docker integration phase (which stays serial).
- **`launch`** — Phases 2–4 (lint ‖ security ‖ build) fan out after the test gate; fixed-interval health retry → **bounded exponential backoff**; gate-cache write migrated from bare-HEAD to `gate-pass.py` tree token.

**Drift fix (folded in):**
- **`push`** — Phase 0 gate-cache was still bare-HEAD while `/commit` (and the `gate-on-commit` hook from #22) use the `gate-pass.py` tree token — they write the **same file** in incompatible formats. Migrated push to the tree token so commit/push/hook share one cache contract.

## Acceptance criteria (#25)
- [x] `orchestrate` documents a concrete Workflow fan-out example
- [x] `gate` aggregates parallel structured verdicts rather than serial ASCII boxes
- [x] `subagents` specifies a structured return schema

## Scope guardrails
- **No generator changes** (stays out of #34's lane).
- `e2e-patterns.md` broken ref (`test:384`) left for **#27**.

## Verification
- `meta-check.py` ✓ · 46 repo tests ✓ · `trigger-overlap.py --strict` ✓ · `eval-harness validate` (32 files) ✓ · `emit-concat` smoke (fan-out content present, frontmatter stripped) ✓

Design doc: `docs/superpowers/specs/2026-05-31-workflow-fanout-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
