### PR TITLE
feat: shared stack-detection + de-hardcode GCP/npm in architect/issue/fix-bugs (#26)

### DIFF
--- a/adapters/lib/modules.py
+++ b/adapters/lib/modules.py
@@ -255,6 +255,10 @@ def cmd_emit_claude_code():
     for module_dir in sorted(MODULES_DIR.glob("*")):
         if not module_dir.is_dir():
             continue
+        # A module is a dir with a SKILL.md. Shared-reference dirs (e.g. `_lib/`, which
+        # holds maintainer conventions in reference.md) have none — skip, don't emit them.
+        if not (module_dir / "SKILL.md").is_file():
+            continue
         slug = module_dir.name
         target = skills_dir / slug
         if target.exists():

--- a/docs/superpowers/specs/2026-05-31-stack-detection-design.md
+++ b/docs/superpowers/specs/2026-05-31-stack-detection-design.md
@@ -1,0 +1,86 @@
+# Design — Issue #26: Shared stack-detection helper + de-hardcode GCP/npm
+
+_Source: 100x-dev power-up review (Theme 6). Priority P1 · Effort L._
+_Parent spec: `2026-05-31-100x-powerup-review-design.md`._
+
+## Problem
+
+`architect`, `issue`, and `fix-bugs` independently hardcode GCP+Firebase+Stripe+Resend
+and npm/pytest, producing wrong-stack advice and broken commands (e.g.
+`gcloud logging … --project=<project>` runs the literal placeholder) for
+AWS/Vercel/pnpm/go/cargo users. `architect` also has a malformed `description: >`
+block-scalar that strips its natural-language triggers, and a "property lookups" domain
+leak from the source project.
+
+## Constraints
+
+- Each skill is emitted **standalone to 7 platforms**, so a shared *runtime* file isn't
+  reliably present (the fragility #31 flags for db's hardcoded `~/.claude` path). "Detected
+  once" therefore means **one canonical snippet** embedded per skill, with a single
+  maintainer source of truth — not a sourced file.
+- **No generator changes.** The shared doc is `reference.md` (not `SKILL.md`), so it is
+  never globbed, emitted, or counted; meta-check stays green.
+- cloud-security's full multi-cloud split is **#32** — here we only add the shared
+  detector it will later consume.
+
+## Design
+
+### Canonical detection block — source of truth: `modules/_lib/reference.md`
+
+Restores `_lib` (dropped in the v2.0.0 unification) as a **reference-only** maintainer
+doc holding the shared conventions (preamble, autonomy banner, GATE format, `/connect`
+credentials) **plus** a new stack-detection preamble. Pure detection, no output — sets
+shell vars the prose branches on:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel); cd "$PROJECT_ROOT"
+INSTRUCTION_FILE=$(for f in CLAUDE.md AGENTS.md .cursorrules .windsurfrules .github/copilot-instructions.md GEMINI.md; do [ -f "$PROJECT_ROOT/$f" ] && echo "$PROJECT_ROOT/$f" && break; done)
+
+# CLOUD: gcp | aws | azure | vercel | ""   (gcloud config / aws / .vercel / terraform / instruction-file grep)
+# TEST_RUNNER: jest | vitest | pytest | "go test" | "cargo test" | ""   (lockfiles + manifests)
+# CI_SYSTEM: github-actions | gitlab | circle | ""   (.github/workflows, .gitlab-ci.yml, .circleci)
+```
+
+Detection is **lightweight** — config + lockfile + IaC + instruction-file greps, no
+network calls. Each of the 3 skills embeds the block verbatim at its first step and cites
+`_lib` as the source.
+
+### Per-skill changes
+
+- **`architect`**
+  - Replace the `description: >` block-scalar with a keyword-packed one-liner (triggers:
+    "should we use X or Y", scaling, cost, data-tier, multi-tenancy, decision matrix);
+    move the Scope note into the body.
+  - Run the detection block in Step 1; reframe Steps 2–3 lenses as **provider-neutral**
+    (compute / networking / data-tier / resilience) with **GCP and AWS named as parallel
+    examples**, not the assumed stack. Genericize the Step 7 topology diagram.
+  - Delete the "should not block **property lookups**" domain leak → "unrelated requests".
+- **`issue`**
+  - Detection block in Phase 1; gate the `gcloud logging` read behind `CLOUD=gcp` and
+    resolve the project from `gcloud config get-value project`, not the literal
+    `<project>`.
+  - Rename dimension 2.3 "Cloud Architecture" provider-neutral; soften 2.5's hardcoded
+    Stripe/Firebase/Resend to "payment / auth / email providers (e.g. …)".
+  - Upgrade the duplicate-issue check from `gh issue list | grep` to fetching titles +
+    bodies and matching semantically; gate behind `gh` availability.
+- **`fix-bugs`**
+  - Move the `systematic-debugging` escalation from the end note **up to Phase 1** as a
+    branch (root cause unclear → diagnose first).
+  - Gate the Phase 1 `gh run` path behind `CI_SYSTEM=github-actions` + `gh` present.
+  - Phase 4 verify uses `$TEST_RUNNER` (or defers to `/test`) instead of hardcoded
+    `npm test` / `pytest`.
+
+## Acceptance criteria (from #26)
+
+- [ ] On a non-GCP repo, none of the three skills emit gcloud commands or GCP-only sections.
+- [ ] `architect` triggers on "should we use X or Y / scaling / decision matrix" without
+      naming the command.
+- [ ] `fix-bugs` uses the detected test runner.
+
+## Testing / verification
+
+- `meta-check.py` (counts unchanged — `_lib` has no SKILL.md), 46 repo tests,
+  `trigger-overlap.py --strict`, `eval-harness validate`.
+- `modules-frontmatter.test.js` must accept architect's new one-liner description.
+- Manual: confirm the GCP sections are gated and the AWS/Vercel/go/cargo paths read
+  correctly; confirm architect's description yields real trigger phrases.

--- a/modules/_lib/reference.md
+++ b/modules/_lib/reference.md
@@ -1,0 +1,77 @@
+# _lib — Shared Workflow Conventions
+
+<!-- Reference only — maintainer source of truth. This is reference.md, NOT SKILL.md, so
+     it is never globbed by adapters/lib/modules.py, never emitted to any platform, and
+     never counted as a module. Skills embed the relevant block verbatim (each skill is
+     emitted standalone to 7 platforms, so a sourced/cat'd runtime file is not reliably
+     present). Keep the canonical copy here; update embedders when it changes. -->
+
+## Standard preamble (paste into every workflow's first bash block)
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel); cd "$PROJECT_ROOT"
+INSTRUCTION_FILE=$(for f in CLAUDE.md AGENTS.md .cursorrules .windsurfrules .github/copilot-instructions.md GEMINI.md; do [ -f "$PROJECT_ROOT/$f" ] && echo "$PROJECT_ROOT/$f" && break; done)
+```
+
+## Stack detection (paste where a workflow needs the cloud/test/CI stack)
+
+Detect the project's stack **once**, then branch on the variables — never hardcode
+GCP/Firebase/Stripe/npm. Detection is lightweight (config + lockfiles + IaC +
+instruction-file greps); **no network calls**. Empty string = "not detected / not
+applicable" → skip that provider's section rather than emitting a broken command.
+
+```bash
+# --- Cloud provider: gcp | aws | azure | vercel | "" ---------------------------------
+CLOUD=""
+if command -v gcloud >/dev/null 2>&1 && gcloud config get-value project >/dev/null 2>&1; then CLOUD=gcp; fi
+[ -z "$CLOUD" ] && ls "$PROJECT_ROOT"/.vercel >/dev/null 2>&1 && CLOUD=vercel
+[ -z "$CLOUD" ] && grep -rqiE "aws_|amazonaws|cdk\.json|::aws" "$PROJECT_ROOT"/terraform "$PROJECT_ROOT"/infra "$PROJECT_ROOT"/cdk.json 2>/dev/null && CLOUD=aws
+[ -z "$CLOUD" ] && grep -rqiE "azurerm|azure-|microsoft\.web" "$PROJECT_ROOT"/terraform "$PROJECT_ROOT"/infra 2>/dev/null && CLOUD=azure
+# Fall back to whatever the instruction file names, if anything.
+if [ -z "$CLOUD" ] && [ -n "$INSTRUCTION_FILE" ]; then
+  grep -qiE "gcloud|Cloud Run|Cloud SQL|Firebase|GCP_PROJECT" "$INSTRUCTION_FILE" && CLOUD=gcp
+  [ -z "$CLOUD" ] && grep -qiE "\baws\b|lambda|dynamodb|ecs|fargate" "$INSTRUCTION_FILE" && CLOUD=aws
+  [ -z "$CLOUD" ] && grep -qiE "vercel" "$INSTRUCTION_FILE" && CLOUD=vercel
+fi
+
+# --- Test runner: jest | vitest | pytest | "go test" | "cargo test" | "" --------------
+TEST_RUNNER=""
+if [ -f "$PROJECT_ROOT/package.json" ]; then
+  grep -q '"vitest"' "$PROJECT_ROOT"/package.json "$PROJECT_ROOT"/*/package.json 2>/dev/null && TEST_RUNNER=vitest
+  [ -z "$TEST_RUNNER" ] && grep -q '"jest"' "$PROJECT_ROOT"/package.json "$PROJECT_ROOT"/*/package.json 2>/dev/null && TEST_RUNNER=jest
+fi
+[ -z "$TEST_RUNNER" ] && { [ -f "$PROJECT_ROOT/pyproject.toml" ] || ls "$PROJECT_ROOT"/requirements*.txt >/dev/null 2>&1; } && TEST_RUNNER=pytest
+[ -z "$TEST_RUNNER" ] && [ -f "$PROJECT_ROOT/go.mod" ] && TEST_RUNNER="go test"
+[ -z "$TEST_RUNNER" ] && [ -f "$PROJECT_ROOT/Cargo.toml" ] && TEST_RUNNER="cargo test"
+
+# --- Package manager (JS): pnpm | yarn | npm | "" -------------------------------------
+JS_PM=""
+[ -f "$PROJECT_ROOT/pnpm-lock.yaml" ] && JS_PM=pnpm
+[ -z "$JS_PM" ] && [ -f "$PROJECT_ROOT/yarn.lock" ] && JS_PM=yarn
+[ -z "$JS_PM" ] && [ -f "$PROJECT_ROOT/package-lock.json" ] && JS_PM=npm
+
+# --- CI system: github-actions | gitlab | circle | "" ---------------------------------
+CI_SYSTEM=""
+ls "$PROJECT_ROOT"/.github/workflows/*.y*ml >/dev/null 2>&1 && CI_SYSTEM=github-actions
+[ -z "$CI_SYSTEM" ] && [ -f "$PROJECT_ROOT/.gitlab-ci.yml" ] && CI_SYSTEM=gitlab
+[ -z "$CI_SYSTEM" ] && [ -d "$PROJECT_ROOT/.circleci" ] && CI_SYSTEM=circle
+
+echo "stack: cloud=${CLOUD:-none} test=${TEST_RUNNER:-none} js_pm=${JS_PM:-none} ci=${CI_SYSTEM:-none}"
+```
+
+## Autonomy banner
+Add to any workflow that operates without user prompting:
+```
+## Do NOT ask for permission — [action]. Do NOT stop until done.
+```
+
+## GATE line format
+```
+**GATE: [Condition that must be true before proceeding.]**
+```
+
+## SaaS credentials
+When a workflow requires cloud or SaaS credentials, reference the **connect** workflow:
+- Run `/connect` to see status of all services
+- Run `/connect <service>` to install CLI + authenticate a specific service
+- Credentials are stored in `.env` (copy `.env.example` to start)

--- a/modules/architect/SKILL.md
+++ b/modules/architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-description: > **Scope:** `/architect` answers architectural questions and produces decision matrices.
+description: Architectural decision advisor for cloud, data, and SaaS distributed systems. Use when the user asks "should we use X or Y", weighs a tradeoff, or needs a decision matrix, scaling analysis, cost-at-scale review, data-tier design, multi-tenancy model, or API/resilience guidance. For full technical blueprints, use enterprise-design.
 category: docs
 tier: on-demand
 slash_command: /architect
@@ -26,28 +26,53 @@ You are a principal architect with deep expertise in cloud infrastructure (GCP/A
 
 ## Step 1 — Load project context
 
-Read the project instruction file and relevant source files to understand:
+Detect the stack first (canonical block — source: `_lib/reference.md`), then read the
+instruction file. **Do not assume GCP/Firebase/npm** — branch on what is detected.
 
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-# Detect project instruction file
+PROJECT_ROOT=$(git rev-parse --show-toplevel); cd "$PROJECT_ROOT"
 INSTRUCTION_FILE=$(for f in CLAUDE.md AGENTS.md .cursorrules .windsurfrules .github/copilot-instructions.md GEMINI.md; do [ -f "$PROJECT_ROOT/$f" ] && echo "$PROJECT_ROOT/$f" && break; done)
-[ -n "$INSTRUCTION_FILE" ] && cat "$INSTRUCTION_FILE" 2>/dev/null | head -100
+
+# Cloud provider: gcp | aws | azure | vercel | "" (config / IaC / instruction-file grep — no network)
+CLOUD=""
+if command -v gcloud >/dev/null 2>&1 && gcloud config get-value project >/dev/null 2>&1; then CLOUD=gcp; fi
+[ -z "$CLOUD" ] && ls "$PROJECT_ROOT"/.vercel >/dev/null 2>&1 && CLOUD=vercel
+[ -z "$CLOUD" ] && grep -rqiE "aws_|amazonaws|cdk\.json|::aws" "$PROJECT_ROOT"/terraform "$PROJECT_ROOT"/infra "$PROJECT_ROOT"/cdk.json 2>/dev/null && CLOUD=aws
+[ -z "$CLOUD" ] && grep -rqiE "azurerm|azure-|microsoft\.web" "$PROJECT_ROOT"/terraform "$PROJECT_ROOT"/infra 2>/dev/null && CLOUD=azure
+if [ -z "$CLOUD" ] && [ -n "$INSTRUCTION_FILE" ]; then
+  grep -qiE "gcloud|Cloud Run|Cloud SQL|Firebase|GCP_PROJECT" "$INSTRUCTION_FILE" && CLOUD=gcp
+  [ -z "$CLOUD" ] && grep -qiE "\baws\b|lambda|dynamodb|ecs|fargate" "$INSTRUCTION_FILE" && CLOUD=aws
+fi
+echo "cloud=${CLOUD:-unknown}"
+[ -n "$INSTRUCTION_FILE" ] && head -100 "$INSTRUCTION_FILE" 2>/dev/null
 ```
 
-Identify:
-- Current cloud stack (GCP services, regions, deployment model)
-- Data storage tier (Cloud SQL schema, Redis usage, BigQuery, GCS)
-- API and service topology (Cloud Run services, async workers, webhooks)
-- Authentication model (Firebase Auth, JWT, OAuth)
-- Current scale characteristics (users, RPM, data volume — from the project instruction file or codebase)
+Identify (map each to the **detected** provider's equivalents — the parenthetical names a
+GCP example and its AWS analog; substitute for whatever `$CLOUD` is):
+- Compute & deployment model (Cloud Run / ECS-Fargate-Lambda / Vercel functions), regions
+- Data storage tiers (Cloud SQL / RDS-Aurora; Memorystore / ElastiCache; BigQuery / Redshift; GCS / S3)
+- API and service topology (managed-container services, async workers, webhooks)
+- Authentication model (Firebase Auth / Cognito / Auth0, JWT, OAuth)
+- Current scale characteristics (users, RPM, data volume — from the instruction file or codebase)
 - Known bottlenecks or constraints
+
+If `$CLOUD` is unknown, ask the user which provider they target before giving
+provider-specific advice.
 
 ---
 
 ## Step 2 — Cloud Architecture Analysis
 
 Examine the topic through the cloud infrastructure lens.
+
+> The bullets below name **GCP services as concrete examples**. Map each to the detected
+> `$CLOUD` provider's equivalent and use that vocabulary in your analysis:
+> Cloud Run → ECS/Fargate, Lambda, App Runner (AWS) · Container Apps, App Service (Azure) · Vercel/Netlify functions ·
+> Cloud SQL → RDS/Aurora · Azure SQL · Neon/PlanetScale ·
+> Memorystore → ElastiCache · Azure Cache ·
+> Pub/Sub → SNS+SQS, EventBridge · Service Bus ·
+> Secret Manager → Secrets Manager/SSM · Key Vault.
+> If `$CLOUD` is unknown, present the analysis provider-neutrally.
 
 ### Compute & Deployment
 - Is Cloud Run the right compute model? Consider: request duration, CPU burstiness, cold start sensitivity, concurrency limits
@@ -82,13 +107,14 @@ Examine the topic through the data lens.
 
 ### Storage Tier Design
 ```
-Hot tier:   Redis (Memorystore)      — sessions, rate limits, LLM cache, real-time
-Warm tier:  Cloud SQL (PostgreSQL)   — transactional data, user records, audit log
-Cold tier:  BigQuery                 — analytics, exports, ML features
-Archive:    GCS                      — reports, backups, blobs
+Hot tier:   in-memory cache   — sessions, rate limits, LLM cache, real-time   (Memorystore / ElastiCache / Azure Cache)
+Warm tier:  relational DB     — transactional data, user records, audit log   (Cloud SQL / RDS-Aurora / Azure SQL / Neon)
+Cold tier:  analytics warehouse — analytics, exports, ML features             (BigQuery / Redshift / Snowflake)
+Archive:    object store      — reports, backups, blobs                        (GCS / S3 / Azure Blob)
 ```
 
-For the topic: which tier(s) are involved? Is data in the right tier?
+For the topic: which tier(s) are involved? Is data in the right tier? (Names in parens are
+per-provider examples — use the `$CLOUD` column.)
 
 ### Schema & Query Design
 - Table design: normalization level appropriate for access patterns?
@@ -144,7 +170,7 @@ Current model assessment and recommendation for the topic.
 - Dead letter queue: maximum retries, alerting on DLQ messages
 
 ### Resilience Patterns
-- Bulkhead: isolate failures (LLM slowness should not block property lookups)
+- Bulkhead: isolate failures (slowness in one dependency should not block unrelated requests)
 - Circuit breaker: open after N failures, half-open probe, close on success
 - Graceful degradation: what is the fallback when AI agents are slow/down?
 - Chaos engineering: have you tested: Cloud SQL restart, Redis flush, Pub/Sub delay?
@@ -184,21 +210,23 @@ When comparing options:
 
 ## Step 7 — Architecture Diagram
 
-For significant proposals, produce a text-based topology diagram:
+For significant proposals, produce a text-based topology diagram using the detected
+`$CLOUD` provider's service names. Example shape (GCP names shown — substitute the AWS /
+Azure / Vercel equivalents for the actual stack):
 
 ```
 ┌─────────────────────────────────────────────────────┐
 │                    CLOUD TOPOLOGY                   │
 ├─────────────────────────────────────────────────────┤
-│  [Firebase Hosting]  ──→  [Cloud Run: API]          │
+│  [Static hosting]  ──→  [API service]               │
 │                               │                     │
 │              ┌────────────────┼──────────────┐      │
 │              ↓                ↓              ↓      │
-│  [Cloud SQL: Primary]  [Redis Cache]  [Pub/Sub]     │
+│  [Relational DB: Primary] [Cache]    [Message bus]  │
 │              │                              │       │
-│   [Cloud SQL: Replica]              [Cloud Run: Worker] │
+│   [DB: Replica]                     [Worker service]│
 │                                             │       │
-│                                    [BigQuery Export]│
+│                                  [Analytics warehouse]│
 └─────────────────────────────────────────────────────┘
 ```
 

--- a/modules/fix-bugs/SKILL.md
+++ b/modules/fix-bugs/SKILL.md
@@ -25,14 +25,32 @@ Fix the bug described or linked. Investigate and fix without step-by-step guidan
 
 Read the error in full — message, stack trace, or thread. Do not skip this step.
 
+**If the root cause is not obvious from the error/stack/logs → invoke the
+`systematic-debugging` skill first to diagnose before attempting any fix.** `/fix` assumes
+you know (or can quickly find) what's broken; for mysterious failures, diagnosis comes
+first. Don't guess.
+
+Detect the stack so context-gathering matches the project (canonical block — source:
+`_lib/reference.md`):
+
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT"
-# If fixing CI: read most recent failure
-gh run list --limit 3
-gh run view --log-failed $(gh run list --limit 1 --json databaseId -q '.[0].databaseId') 2>/dev/null | tail -80
+PROJECT_ROOT=$(git rev-parse --show-toplevel); cd "$PROJECT_ROOT"
+CI_SYSTEM=""; ls "$PROJECT_ROOT"/.github/workflows/*.y*ml >/dev/null 2>&1 && CI_SYSTEM=github-actions
+TEST_RUNNER=""
+grep -q '"vitest"' package.json */package.json 2>/dev/null && TEST_RUNNER=vitest
+[ -z "$TEST_RUNNER" ] && grep -q '"jest"' package.json */package.json 2>/dev/null && TEST_RUNNER=jest
+[ -z "$TEST_RUNNER" ] && { [ -f pyproject.toml ] || ls requirements*.txt >/dev/null 2>&1; } && TEST_RUNNER=pytest
+[ -z "$TEST_RUNNER" ] && [ -f go.mod ] && TEST_RUNNER="go test"
+[ -z "$TEST_RUNNER" ] && [ -f Cargo.toml ] && TEST_RUNNER="cargo test"
+
+# If fixing CI on a GitHub-Actions repo with gh available: read the most recent failure
+if [ "$CI_SYSTEM" = github-actions ] && command -v gh >/dev/null 2>&1; then
+  gh run list --limit 3
+  gh run view --log-failed "$(gh run list --limit 1 --json databaseId -q '.[0].databaseId')" 2>/dev/null | tail -80
+fi
 ```
 
+For non-GitHub CI, read the failing job from that provider (GitLab/CircleCI UI or CLI).
 For docker logs: parse for ERROR/CRITICAL lines, identify service + file.
 For Slack thread: extract the bug report and reproduction steps.
 
@@ -62,22 +80,24 @@ If the root cause cannot be determined: say so clearly. Do not guess.
 
 ## Phase 4 — Verify
 
-Run the specific failing test or reproduce the failure condition:
+Run the specific failing test or reproduce the failure condition, using the
+**detected** `$TEST_RUNNER` from Phase 1 (or just defer to `/test`, which auto-detects
+every layer):
 
 ```bash
-# Run the test(s) that were failing
-npm test 2>&1 | tail -30
-# or
-./venv/bin/pytest tests/ -v --tb=short -q 2>&1 | tail -30
+# Target only the failing test(s) — substitute the file/name that was failing.
+case "$TEST_RUNNER" in
+  vitest|jest)  npx "$TEST_RUNNER" run <failing-test> 2>&1 | tail -30 ;;
+  pytest)       ./venv/bin/pytest <failing-test> -v --tb=short -q 2>&1 | tail -30 ;;
+  "go test")    go test ./<pkg> -run '<TestName>' 2>&1 | tail -30 ;;
+  "cargo test") cargo test <test_name> 2>&1 | tail -30 ;;
+  *)            echo "No test runner detected — run /test, or reproduce the failure manually" ;;
+esac
 ```
 
 **GATE: The specific failure condition no longer occurs.**
 
 ---
-
-## Note on unknown root causes
-
-If the root cause is not clear from the error, stack trace, or logs alone — **invoke `systematic-debugging` skill first** to diagnose before attempting a fix. `/fix` assumes you know (or can quickly find) what's broken. For mysterious failures, diagnosis comes first.
 
 ## Phase 5 — Summarize
 

--- a/modules/issue/SKILL.md
+++ b/modules/issue/SKILL.md
@@ -19,10 +19,18 @@ You are a senior engineering lead and product architect. Given an observation, b
 Understand the problem in full context before forming any opinion.
 
 ```bash
-PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT"
+PROJECT_ROOT=$(git rev-parse --show-toplevel); cd "$PROJECT_ROOT"
 git log --oneline -20
 git status
+
+# Detect the stack so later steps don't assume GCP/npm (canonical block — source: _lib/reference.md)
+INSTRUCTION_FILE=$(for f in CLAUDE.md AGENTS.md .cursorrules .windsurfrules .github/copilot-instructions.md GEMINI.md; do [ -f "$PROJECT_ROOT/$f" ] && echo "$PROJECT_ROOT/$f" && break; done)
+CLOUD=""
+if command -v gcloud >/dev/null 2>&1 && gcloud config get-value project >/dev/null 2>&1; then CLOUD=gcp; fi
+[ -z "$CLOUD" ] && grep -rqiE "aws_|amazonaws|::aws" "$PROJECT_ROOT"/terraform "$PROJECT_ROOT"/infra "$PROJECT_ROOT"/cdk.json 2>/dev/null && CLOUD=aws
+[ -z "$CLOUD" ] && [ -n "$INSTRUCTION_FILE" ] && grep -qiE "gcloud|Cloud Run|Firebase" "$INSTRUCTION_FILE" && CLOUD=gcp
+CI_SYSTEM=""; ls "$PROJECT_ROOT"/.github/workflows/*.y*ml >/dev/null 2>&1 && CI_SYSTEM=github-actions
+echo "stack: cloud=${CLOUD:-none} ci=${CI_SYSTEM:-none}"
 ```
 
 1. Search for all code relevant to the observation (routes, components, services, DB queries, migrations, tests)
@@ -31,16 +39,28 @@ git status
    ```bash
    git log --oneline --since="60 days ago" -- <relevant-paths>
    ```
-4. Check for existing related issues:
+4. Check for existing related issues (only if `gh` is available). Pull titles **and
+   bodies**, then match on *meaning*, not just a keyword grep — a dupe often uses
+   different words for the same root cause:
    ```bash
-   gh issue list --state open | grep -i "<keywords from observation>"
+   command -v gh >/dev/null 2>&1 && gh issue list --state all --limit 100 \
+     --json number,title,body -q '.[] | "#\(.number) \(.title)\n\(.body)\n---"' 2>/dev/null
    ```
+   Read the results and judge whether any existing issue describes the same underlying
+   problem; if so, reference or update it instead of filing a duplicate.
 5. Check current test coverage for the affected code paths
-6. Check Cloud Run logs if this is a production issue:
+6. **If this is a production issue and `CLOUD=gcp`**, check Cloud Run logs (resolve the
+   project from gcloud config — never pass a literal placeholder):
    ```bash
-   gcloud logging read "resource.type=cloud_run_revision AND severity>=ERROR" \
-     --project=<project> --limit=20 --format="value(textPayload)" 2>/dev/null || true
+   if [ "$CLOUD" = gcp ]; then
+     PROJECT=$(gcloud config get-value project 2>/dev/null)
+     gcloud logging read "resource.type=cloud_run_revision AND severity>=ERROR" \
+       --project="$PROJECT" --limit=20 --format="value(textPayload)" 2>/dev/null || true
+   fi
    ```
+   For other providers, read logs the platform-appropriate way (AWS: `aws logs tail`;
+   Vercel: `vercel logs`; or the project's configured log viewer). Skip if not a
+   production issue.
 
 ---
 
@@ -57,8 +77,9 @@ Analyze from ALL FIVE perspectives before forming a resolution plan.
 - What does the user actually see? Exact errors or broken states?
 - Data loss, incorrect data, or silent failure? Accessibility / performance impact?
 
-### 2.3 Cloud Architecture
-- Which GCP services involved (Cloud Run, Cloud SQL, GCS, Pub/Sub, Redis, Firebase)?
+### 2.3 Cloud / Infrastructure
+- Which `$CLOUD` services are involved? (GCP: Cloud Run/Cloud SQL/GCS/Pub-Sub/Memorystore/Firebase ·
+  AWS: ECS-Lambda/RDS/S3/SNS-SQS/ElastiCache/Cognito · Azure / Vercel equivalents.) Map to the detected stack.
 - Scaling, concurrency, IAM, networking, or cold-start related?
 
 ### 2.4 Data Architecture
@@ -67,7 +88,8 @@ Analyze from ALL FIVE perspectives before forming a resolution plan.
 
 ### 2.5 SaaS / Distributed Systems
 - Race condition, multi-tenancy isolation risk, or async/webhook issue?
-- Third-party dependency (Stripe, Firebase Auth, Resend)? Retry/idempotency gap?
+- Third-party dependency — payment / auth / email / SMS provider (e.g. Stripe, the auth
+  provider, the email sender)? Retry/idempotency gap?
 
 ---
 
@@ -190,14 +212,14 @@ gh issue create \
 ### User Experience
 <!-- what the user sees, data loss risk, accessibility/perf impact -->
 
-### Cloud Architecture
-<!-- which GCP services involved, scaling/infra implications -->
+### Cloud / Infrastructure
+<!-- which cloud services involved (map to the project's provider), scaling/infra implications -->
 
 ### Data Architecture
 <!-- tables/queries affected, migration needed, data integrity risk -->
 
 ### SaaS / Distributed Systems
-<!-- race conditions, multi-tenancy, async/webhook, third-party deps -->
+<!-- race conditions, multi-tenancy, async/webhook, third-party deps (payment/auth/email) -->
 
 ## Resolution Plan
 

--- a/scripts/trigger-overlap-allow.txt
+++ b/scripts/trigger-overlap-allow.txt
@@ -50,3 +50,8 @@ seo-audit <-> site-architecture
 competitor-alternatives <-> programmatic-seo
 copy-editing <-> copywriting
 conversion-copy <-> copywriting
+# architect's keyword-packed description (#26) raised two benign overlaps:
+# - enterprise-design: intentional, architect's description cross-references it ("for full blueprints, use enterprise-design")
+# - pr: generic-token overlap (~0.17), same class as the accepted issue<->pr / context-dump<->pr
+architect <-> enterprise-design
+architect <-> pr


### PR DESCRIPTION
Closes #26.

## What

Theme 6 of the power-up review: `architect`, `issue`, and `fix-bugs` independently hardcoded GCP+Firebase+Stripe+Resend and npm/pytest — emitting wrong-stack advice and broken commands (e.g. `gcloud logging … --project=<project>` ran the literal placeholder) for AWS/Vercel/pnpm/go/cargo users. This adds a shared, network-free **stack-detection** convention and branches on it.

## Changes

**Shared helper — `modules/_lib/reference.md`** (restored)
- `_lib` was a reference-only conventions doc dropped in the v2.0.0 unification. Re-established as `reference.md` (**not** `SKILL.md`) so it's a maintainer source-of-truth that is never globbed, emitted, or counted as a module.
- Holds the canonical detection block: `CLOUD` (gcp/aws/azure/vercel), `TEST_RUNNER` (jest/vitest/pytest/go/cargo), `JS_PM`, `CI_SYSTEM` — all from config + lockfiles + IaC + instruction-file greps, **no network calls**. Each skill embeds the relevant slice verbatim (skills emit standalone to 7 platforms, so a sourced runtime file isn't reliably present — the fragility #31 flags).

**`architect`**
- Replaced the malformed `description: >` block-scalar (which stripped all natural-language triggers) with a keyword-packed one-liner ("should we use X or Y", scaling, cost, data-tier, multi-tenancy, decision matrix).
- Detects stack in Step 1; reframed the cloud/data lenses + topology diagram with **GCP as one example** mapped to AWS/Azure/Vercel equivalents.
- Removed the "property lookups" domain leak from the source project.

**`issue`**
- Detects stack in Phase 1; gates the Cloud Run log read behind `CLOUD=gcp` and resolves the project from `gcloud config` instead of the literal `<project>`.
- Genericized impact dimensions 2.3/2.5 + the issue-template comments.
- Upgraded the duplicate-issue check from `gh issue list | grep` to a titles+bodies **semantic** match (gated behind `gh` availability).

**`fix-bugs`**
- Moved the `systematic-debugging` escalation up to **Phase 1** (was a buried end note).
- Gated the `gh run` CI path behind `CI_SYSTEM=github-actions` + `gh` present.
- Phase 4 verify uses the detected `$TEST_RUNNER` (or defers to `/test`) instead of hardcoded `npm test`/`pytest`.

**`adapters/lib/modules.py`**
- `emit-claude-code` now skips module dirs without a `SKILL.md` (matches the `list_modules` `*/SKILL.md` contract), so the `_lib` reference dir is never emitted. A 2-line robustness fix the existing `modules-frontmatter.test.js` now guards.

**`scripts/trigger-overlap-allow.txt`**
- Allow-listed architect's two benign new overlaps: `enterprise-design` (intentional — its description cross-references it) and `pr` (generic-token, ~0.17, same class as the accepted `issue ⇄ pr`).

## Acceptance criteria (#26)
- [x] On a non-GCP repo, none of the three skills emit gcloud commands or GCP-only sections (all gated behind `CLOUD=gcp`).
- [x] `architect` triggers on "should we use X or Y / scaling / decision matrix" without naming the command.
- [x] `fix-bugs` uses the detected test runner.

## Scope guardrails
- cloud-security's full multi-cloud split is **#32** — this only adds the shared detector it will consume.

## Verification
- `meta-check.py` (65 modules, `_lib` excluded) ✓ · 46 repo tests ✓ · `trigger-overlap.py --strict` ✓ · `eval-harness validate` (32 files) ✓ · `emit-claude-code` smoke (65 skills, `_lib` not emitted) ✓

Design doc: `docs/superpowers/specs/2026-05-31-stack-detection-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
