### PR TITLE
fix(update): make plugin updates scope-aware (user → project → local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **`update.sh`** — `run_plugin_updates()` is now scope-aware. `claude plugin update` defaults to **user** scope and exits non-zero with *"not installed at scope user"* for plugins installed at **project**/**local** scope — which surfaced as spurious update failures (e.g. `ui-ux-pro-max@ui-ux-pro-max-skill`, `understand-anything@understand-anything`). Each plugin is now retried across `user → project → local` and only reported failed when it is absent from every scope. The plugin **name was never wrong** — the id form `name@marketplace` is correct; the bug was scope handling.
+- **`update.sh`** — added a `CLAUDE_BIN` override and a `UPDATE_SH_SOURCE_ONLY` source-only guard so the plugin-update logic is unit-testable; **`test/update-plugins.test.js`** covers the project-scope, user-scope, and absent-from-all-scopes paths against a stubbed CLI.
+
+---
+
 ## [2.1.0] — 2026-05-31
 
 Frontier-model modernization (issues #21–#27) — generator-layer model routing, enforcing hooks, an eval/meta safety net, Workflow/subagent fan-out, and stack-detection de-hardcoding. Backward compatible; new behavior is opt-in.

--- a/test/update-plugins.test.js
+++ b/test/update-plugins.test.js
@@ -1,0 +1,93 @@
+'use strict'
+
+// Verifies update.sh's run_plugin_updates() is scope-aware (rectifies the
+// project/local-scope false-failure for understand-anything / ui-ux-pro-max):
+//   - a plugin installed at project scope (fails at user scope) is still updated
+//   - a plugin absent from every scope is reported as failed
+//
+// The shell function is loaded in isolation via UPDATE_SH_SOURCE_ONLY=1 and run
+// against a stubbed `claude` CLI injected through CLAUDE_BIN, so no real plugin
+// installs or network access are touched.
+
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const REPO = path.resolve(__dirname, '..')
+const UPDATE_SH = path.join(REPO, 'update.sh')
+
+// Build a throwaway workspace: a fake REPO_DIR holding plugins/plugins.json and
+// a stub `claude` whose per-scope behaviour is scripted by a manifest file.
+function workspace(plugins, behaviour) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), '100x-upd-'))
+  fs.mkdirSync(path.join(dir, 'plugins'))
+  fs.writeFileSync(
+    path.join(dir, 'plugins', 'plugins.json'),
+    JSON.stringify({ plugins }, null, 2),
+  )
+
+  // behaviour: { "<id>": ["scope-that-succeeds", ...] }. The stub exits 0 only
+  // when invoked as `plugin update <id> --scope <s>` with s in that list.
+  const bin = path.join(dir, 'bin')
+  fs.mkdirSync(bin)
+  fs.writeFileSync(path.join(dir, 'behaviour.json'), JSON.stringify(behaviour))
+  const stub = `#!/usr/bin/env bash
+# args: plugin update <id> --scope <scope>
+id="$3"; scope="$5"
+ok=$(python3 -c "import json,sys; b=json.load(open('${dir}/behaviour.json')); print('1' if sys.argv[2] in b.get(sys.argv[1],[]) else '0')" "$id" "$scope")
+if [ "$ok" = "1" ]; then echo "updated $id @ $scope"; exit 0; fi
+echo "Plugin \\"$id\\" is not installed at scope $scope" >&2
+exit 1
+`
+  fs.writeFileSync(path.join(bin, 'claude'), stub, { mode: 0o755 })
+  return { dir, bin }
+}
+
+function runPluginUpdates({ dir, bin }) {
+  // Source update.sh for its functions only, then call run_plugin_updates with
+  // REPO_DIR pointed at the fake workspace and CLAUDE_BIN at the stub.
+  const script = `
+    set -euo pipefail
+    export UPDATE_SH_SOURCE_ONLY=1
+    export CLAUDE_BIN='${path.join(bin, 'claude')}'
+    source '${UPDATE_SH}'
+    REPO_DIR='${dir}'
+    run_plugin_updates
+  `
+  return spawnSync('bash', ['-c', script], { encoding: 'utf8' })
+}
+
+test('project-scoped plugin updates instead of falsely failing', () => {
+  const ws = workspace(
+    ['ui-ux-pro-max@ui-ux-pro-max-skill'],
+    { 'ui-ux-pro-max@ui-ux-pro-max-skill': ['project'] }, // not at user scope
+  )
+  const r = runPluginUpdates(ws)
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /1 updated/)
+  assert.doesNotMatch(r.stdout, /failed/)
+})
+
+test('user-scoped plugin still updates on the first attempt', () => {
+  const ws = workspace(
+    ['superpowers@claude-plugins-official'],
+    { 'superpowers@claude-plugins-official': ['user'] },
+  )
+  const r = runPluginUpdates(ws)
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /1 updated/)
+})
+
+test('plugin absent from every scope is reported as failed', () => {
+  const ws = workspace(
+    ['ghost@nowhere'],
+    { 'ghost@nowhere': [] }, // fails at user, project, and local
+  )
+  const r = runPluginUpdates(ws)
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /1 failed/)
+  assert.match(r.stdout, /ghost@nowhere/)
+})

--- a/update.sh
+++ b/update.sh
@@ -8,6 +8,8 @@ SKILLS_DIR="$CLAUDE_DIR/skills"
 SETTINGS_FILE="$CLAUDE_DIR/settings.json"
 CHECK_ONLY=false
 PLUGINS_ONLY=false
+# Overridable so tests can stub the CLI (see test/update-plugins.test.js).
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 
 # Colors
 GREEN='\033[0;32m'
@@ -38,7 +40,19 @@ run_plugin_updates() {
 
   local _ok=0 _failed=()
   for _p in "${_plugins[@]}"; do
-    if claude plugin update "$_p" >/dev/null 2>&1; then
+    # A plugin can be installed at user, project, or local scope. `claude plugin
+    # update` defaults to user scope and exits non-zero with "not installed at
+    # scope <s>" when the plugin lives at a different scope — which previously
+    # surfaced as a spurious failure for project/local-scoped plugins. Try each
+    # scope until one updates; only mark failed if it's absent from all of them.
+    local _updated=false _scope
+    for _scope in user project local; do
+      if "$CLAUDE_BIN" plugin update "$_p" --scope "$_scope" >/dev/null 2>&1; then
+        _updated=true
+        break
+      fi
+    done
+    if $_updated; then
       (( _ok++ )) || true
     else
       _failed+=("$_p")
@@ -62,6 +76,13 @@ sync_hooks() {
   [ -f "$SETTINGS_FILE" ] || return 0
   python3 "$REPO_DIR/adapters/lib/modules.py" emit-hooks --sync 2>/dev/null || true
 }
+
+# Test seam: when sourced with UPDATE_SH_SOURCE_ONLY=1, load the functions above
+# without running the update flow, so tests can exercise them against a stubbed
+# CLAUDE_BIN. No effect when the script is executed normally.
+if [ -n "${UPDATE_SH_SOURCE_ONLY:-}" ]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 if [ "$PLUGINS_ONLY" = true ]; then
   echo ""


### PR DESCRIPTION
## Problem

Existing users saw `~/100x-dev/update.sh` report update failures for `understand-anything@understand-anything` and `ui-ux-pro-max@ui-ux-pro-max-skill`. It looked like a wrong plugin name — it isn't.

**Root cause: scope, not name.** `claude plugin update` defaults to **user** scope and exits non-zero with *"not installed at scope user"* when a plugin lives at **project** or **local** scope. `run_plugin_updates()` ran the bare `claude plugin update "$id"` (user scope only), so any plugin a user happened to have at project/local scope was bucketed as failed. The `name@marketplace` id (`ui-ux-pro-max@ui-ux-pro-max-skill`) is correct and verified — confirmed by the update succeeding under `--scope project`.

## Fix

- **Scope fallback** — retry each plugin across `user → project → local`, stop at the first success, and only report failed when it's absent from every scope.
- **Test seam** — add a `CLAUDE_BIN` override and a `UPDATE_SH_SOURCE_ONLY` source-only guard so the shell function can be unit-tested against a stubbed CLI (no real installs / network).
- **`test/update-plugins.test.js`** — covers the project-scope (was-failing), user-scope (first-attempt), and absent-from-all-scopes paths.

## Verification

- ✅ `bash -n update.sh` — syntax OK
- ✅ Full suite — **49/49** (3 new)
- ✅ `meta-check.py` — clean
- ✅ Manually re-ran both plugins at the correct scope on a real machine: `understand-anything` 2.6.3 → 2.7.5, `ui-ux-pro-max` already latest.

## Notes

The plugin *name* concern in roadmap #35 is resolved here as "not a defect" — the actual issue was scope handling, now fixed. Targets `[Unreleased]`; pairs naturally with a future 2.1.1 patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
