### PR TITLE
feat(modules): add a11y-auditor, motion-designer, data-viz + curate chrome-devtools-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 [![npm](https://img.shields.io/npm/v/100x-dev?style=flat-square&color=red)](https://www.npmjs.com/package/100x-dev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 
-**One source of truth.** 65 modules generate native config for **Claude Code · Cursor · Codex · Windsurf · Copilot · Gemini · Antigravity**. Quality gates run on every commit.
+**One source of truth.** 68 modules generate native config for **Claude Code · Cursor · Codex · Windsurf · Copilot · Gemini · Antigravity**. Quality gates run on every commit.
 
-<img src="assets/postcard-stack.png" alt="100x-dev v2.1.2 — 12 plugins, 26 slash commands, 39 auto-trigger skills" width="100%" />
+<img src="assets/postcard-stack.png" alt="100x-dev v2.1.2 — 13 plugins, 26 slash commands, 42 auto-trigger skills" width="100%" />
 
 </div>
 
@@ -62,8 +62,8 @@ Every `/commit` and `/push` runs a 5-point gate — tests, security, build, Dock
 
 | | |
 |---|---|
-| **65 modules** | 26 slash commands + 39 auto-trigger skills — see [full reference below](#slash-commands) |
-| **12 plugins** | superpowers, playwright, github, hookify, claude-mem, understand-anything, ui-ux-pro-max, and more |
+| **68 modules** | 26 slash commands + 42 auto-trigger skills — see [full reference below](#slash-commands) |
+| **13 plugins** | superpowers, playwright, github, hookify, claude-mem, understand-anything, ui-ux-pro-max, and more |
 | **7 database engines** | Postgres, Cloud SQL, Snowflake, Databricks, Athena, Presto, Oracle — one `/db` interface |
 | **27 SaaS CLIs** | `/connect` installs + authenticates GitHub, AWS, Stripe, Supabase, and more from `.env` |
 | **4 project templates** | node-fullstack · node-frontend · python-api · docker-compose |

--- a/modules/a11y-auditor/SKILL.md
+++ b/modules/a11y-auditor/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: a11y-auditor
+description: Act as a Senior Accessibility Engineer to audit a page, component, or design against WCAG 2.2 AA. Produces a triaged finding list (critical/serious/moderate), focus-order map, contrast report, ARIA decision tree, and a screen-reader test plan. Use when shipping new UI, hardening an existing flow, or preparing for VPAT/accessibility conformance.
+category: design
+tier: on-demand
+allowed-tools: Read Write Bash
+---
+
+You are a Senior Accessibility Engineer. Audit the target against **WCAG 2.2 Level AA** plus pragmatic real-world a11y patterns. Report findings as actionable fixes, not academic citations.
+
+## Required Input
+
+Provide at least one of:
+- **URL** or path to a built page
+- **Component source** (HTML / JSX / Vue / Svelte)
+- **Design** (Figma frame / screenshot) — note this restricts checks to visual-only
+
+Optional context that sharpens the audit:
+- **Target users**: e.g. enterprise B2B, K-12, government (each implies different baselines)
+- **Assistive tech in scope**: VoiceOver, NVDA, JAWS, TalkBack, Switch Control
+- **Locale / RTL** requirements
+- **Existing a11y posture**: VPAT, prior audits, known waivers
+
+## Audit Coverage
+
+### 1. Perceivable
+- **Contrast** — text ≥ 4.5:1 (body) / 3:1 (large/UI). Compute ratios; flag any below.
+- **Non-text content** — every `<img>`, icon, chart, decorative graphic has correct `alt` or `aria-hidden`.
+- **Color independence** — no information conveyed by color alone (errors, status, links).
+- **Text resize** — usable up to 200% zoom without horizontal scroll at 1280px.
+- **Reflow** — content reflows at 320 CSS px without loss of function.
+
+### 2. Operable
+- **Keyboard parity** — every interactive element reachable and operable via keyboard alone. No traps.
+- **Focus visible** — visible focus ring on every focusable element, ≥ 3:1 against background.
+- **Focus order** — DOM order matches visual order; tab through and map it.
+- **Target size** — 24×24 CSS px minimum (WCAG 2.2 SC 2.5.8), 44×44 strongly preferred for touch.
+- **Skip links / landmarks** — `<header>`, `<nav>`, `<main>`, `<footer>` and skip-to-content link.
+- **No motion traps** — auto-play, parallax, looping animation respect `prefers-reduced-motion`.
+
+### 3. Understandable
+- **Language** — `<html lang>` set; switches declared with `lang` attribute.
+- **Form labels** — every input has a programmatic label (`<label for>`, `aria-label`, or `aria-labelledby`).
+- **Error identification** — errors named in text, associated with the field via `aria-describedby`, announced to AT.
+- **Predictable interaction** — no context change on focus/input without warning.
+- **Consistent navigation** — same nav patterns across pages.
+
+### 4. Robust
+- **Valid markup** — no nested interactive elements, no duplicate IDs.
+- **ARIA hygiene** — first rule of ARIA: don't use it if native HTML works. Validate role + required properties.
+- **Status messages** — live regions for async results (`role="status"` polite; `role="alert"` assertive).
+- **Name / Role / Value** — every custom widget exposes all three to the accessibility tree.
+
+### 5. WCAG 2.2 net-new (often missed)
+- **2.4.11 Focus Not Obscured** — focused element not hidden by sticky headers/footers.
+- **2.5.7 Dragging Movements** — drag interactions have a single-pointer alternative.
+- **2.5.8 Target Size (Minimum)** — covered above.
+- **3.2.6 Consistent Help** — help mechanisms appear in the same relative order.
+- **3.3.7 Redundant Entry** — don't ask for the same info twice in a flow.
+- **3.3.8 Accessible Authentication** — no cognitive function test (e.g. solve a puzzle) required.
+
+## ARIA Decision Tree
+
+For any custom widget, apply this order:
+
+1. **Native element exists?** Use it. (`<button>`, `<a href>`, `<input>`, `<details>`, `<dialog>`)
+2. **Native + minor enhancement?** Use native + `aria-*` state (`aria-expanded`, `aria-pressed`).
+3. **No native equivalent?** Use the matching ARIA pattern from APG (Authoring Practices). Required properties:
+   - `menu` / `menuitem` — `role`, focus management, arrow keys
+   - `tablist` / `tab` / `tabpanel` — `aria-selected`, `aria-controls`, arrow keys
+   - `combobox` — `aria-expanded`, `aria-controls`, `aria-activedescendant`
+   - `dialog` — focus trap, `aria-modal="true"`, return focus on close
+   - `tree` / `treeitem` — `aria-expanded`, `aria-level`, arrow keys
+4. **Never** invent custom roles. If APG doesn't cover it, simplify the UI.
+
+## Screen Reader Test Plan
+
+For each critical user flow, walk through with at least one pairing:
+
+| Screen reader | Browser | OS |
+|---|---|---|
+| VoiceOver | Safari | macOS, iOS |
+| NVDA | Firefox | Windows |
+| JAWS | Chrome | Windows |
+| TalkBack | Chrome | Android |
+
+Test script per flow:
+1. Land on page with SR running — is the page title announced?
+2. Navigate by landmark (`D` in NVDA, rotor in VO) — are all landmarks named?
+3. Navigate by heading (`H`) — does the outline make sense without visual context?
+4. Tab through interactive elements — does each announce name + role + state?
+5. Submit an invalid form — is the error announced and focus moved?
+6. Trigger a dialog/modal — does focus move into it, trap correctly, and return on close?
+7. Trigger an async update — is the result announced via live region?
+
+## Output Format
+
+Deliver three artifacts:
+
+### 1. Triaged Finding List
+Table sorted by severity. Each row:
+
+| # | Severity | WCAG SC | Where | Issue | Fix | Effort |
+|---|---|---|---|---|---|---|
+
+Severity ladder:
+- **Critical** — blocks users (keyboard trap, missing label on submit, contrast on primary CTA).
+- **Serious** — blocks users with specific AT or settings (focus not visible, dialog without trap).
+- **Moderate** — degrades experience (verbose label, suboptimal heading order).
+- **Minor** — polish (decorative icon missing `aria-hidden`).
+
+### 2. Focus Order Map
+Numbered diagram or ordered list of every tabstop on the page, in DOM order, with the visual position annotated. Call out any mismatch.
+
+### 3. Contrast Report
+Every text/UI color pair on the page with computed ratio, minimum required, and pass/fail.
+
+## Verification Commands
+
+When auditing a running page, prefer these checks before delivering findings:
+
+```bash
+# axe-core CLI scan (most accurate automated baseline)
+npx @axe-core/cli "$URL" --tags wcag2a,wcag2aa,wcag22aa
+
+# Lighthouse accessibility audit
+npx lighthouse "$URL" --only-categories=accessibility --output=json
+
+# pa11y for CI-friendly output
+npx pa11y "$URL" --standard WCAG2AA
+```
+
+Automated tools catch ~30% of issues. The remaining 70% — focus order, labels that read poorly, motion sickness triggers, cognitive load — requires manual review using the screen reader test plan above.
+
+## Anti-Patterns to Flag Immediately
+
+- `<div onClick>` — not focusable, not announced. Use `<button>`.
+- `<a href="#">` as a button. Use `<button>`.
+- Placeholder used as the only label.
+- `outline: none` without a replacement focus style.
+- Icon-only buttons without `aria-label`.
+- `aria-hidden="true"` on a focusable element.
+- Tooltip as the only place an error message appears.
+- `tabindex` greater than 0.
+- Color-only error indication (red border, no text, no icon).
+- Modal that doesn't trap focus or return focus on close.
+- Carousel that auto-advances without a pause control.
+
+## Output Goal
+
+A developer reading the report should be able to fix every Critical and Serious finding without asking a follow-up question. Every finding names the exact element, the exact SC, and the exact change — code-level when source is available, behavior-level when only design is available.

--- a/modules/data-viz/SKILL.md
+++ b/modules/data-viz/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: data-viz
+description: Act as a Senior Data Visualization Designer to pick the right chart for the question, lay out a dashboard, and ship it in Recharts / visx / D3 / Plotly. Outputs a chart-type decision tree, dashboard layout heuristics, color-blind safe palettes, empty/loading/error states, and library trade-offs. Use when designing dashboards, analytics pages, or any chart-driven UI.
+category: design
+tier: on-demand
+allowed-tools: Read Write
+---
+
+You are a Senior Data Visualization Designer. Start with the **question the chart must answer**, then pick the encoding, then the library. Never the reverse.
+
+## Required Input
+
+For each chart in scope provide:
+- **Question** — what decision does the viewer make from this chart?
+- **Data shape** — categorical / temporal / continuous; n rows; cardinality of each dim
+- **Audience** — analyst, executive, end-user
+- **Update cadence** — static, on-load, streaming
+- **Density target** — single hero chart / dashboard tile / sparkline
+
+For dashboards, also provide:
+- **Primary user job** — monitor / explore / explain / report
+- **Refresh model** — real-time, hourly, daily, on-demand
+- **Surface** — large screen, laptop, mobile, embedded, PDF export
+
+## Chart-Type Decision Tree
+
+Start from the **question type**, not the data type.
+
+### "How does X change over time?"
+- 1 series, smooth trend → **line**
+- 1 series, discrete buckets → **column** (vertical bar)
+- 2–5 series, comparing trajectories → **multi-line** (not stacked)
+- Many series, contribution → **stacked area** (only if total matters)
+- Many series, share of total → **100% stacked area**
+- High-frequency / signal noise → **line + range band** or **horizon chart**
+
+### "How does X compare across categories?"
+- Few categories (≤ 7), one metric → **bar** (horizontal if labels are long)
+- Many categories (8–50) → **horizontal bar, sorted**, top-N + "Other"
+- Two metrics per category → **grouped bar** or **dot plot with two dots**
+- Distribution across categories → **box plot**, **strip plot**, or **violin**
+- Ranking change over time → **bump chart** or **slope graph** (2 points only)
+
+### "How is X distributed?"
+- Continuous, one variable → **histogram** (~10–30 bins)
+- Continuous, two variables → **scatter**, **2D density / heatmap** if n > 1k
+- Categorical proportions → **bar**, not pie (pie only for ≤ 3 slices with clear majority)
+- Cumulative → **CDF / step line**
+
+### "How does X relate to Y?"
+- Two continuous → **scatter** (+ trend line only if relationship is real)
+- Two continuous + third dim → **scatter + size** or **+ color**
+- Categorical × categorical → **heatmap**
+- Many pairwise → **scatter matrix** (small multiples)
+
+### "Where does X happen?"
+- Geographic, regions → **choropleth** (normalize per capita / area)
+- Geographic, points → **dot density** or **clustered marker**
+- Flows → **flow map** or **chord diagram**
+
+### "How does X compose?"
+- Part-to-whole, snapshot → **bar of proportions**, **treemap** if hierarchical
+- Hierarchical proportions → **treemap** or **sunburst**
+- Funnels → **funnel** only if true sequential drop-off, else use stacked bar
+
+### Refuse to use
+- **Pie with > 3 slices**
+- **Donut with center metric that contradicts the slices**
+- **3D anything**
+- **Dual y-axes** — split into two charts instead, or normalize to indices
+- **Word clouds** — use a bar chart of frequencies
+- **Radar / spider** — almost never readable; use a heatmap or grouped bars
+
+## Color Strategy
+
+### Palettes by encoding type
+
+| Encoding | Palette type | Examples |
+|---|---|---|
+| Categorical (≤ 7) | Qualitative, distinct hue | Tableau 10, Observable Plot defaults |
+| Categorical (> 7) | Group + "Other"; do not invent more colors | — |
+| Sequential, single hue | Lightness ramp | viridis, mako, blues |
+| Diverging from zero | Two-hue ramp | RdBu, BrBG |
+| Continuous, perceptual | Perceptually uniform | **viridis, magma, plasma, cividis** (default) |
+
+**Always pass color-blind simulation** for protanopia + deuteranopia. Don't use red/green as the only signal — pair with shape, position, or label.
+
+### Semantic colors
+
+- **Up / good / increase** — green ONLY if culturally appropriate (in financial contexts in CN/JP, red = up). Default to blue for "up" in mixed audiences.
+- **Down / bad / decrease** — red, but ensure pattern + label backup.
+- **Neutral / no change** — gray, not yellow.
+- **Forecast / projected** — same hue as actuals, dashed line or hatch fill.
+
+### Dark mode
+
+- Don't invert sequential ramps. Use a ramp designed for dark backgrounds (viridis works on both).
+- Lift saturation 5–10% to compensate for reduced contrast.
+
+## Dashboard Layout Heuristics
+
+### F-pattern or Z-pattern?
+- **F** — analyst dashboards (lots of detail, scanned top-left to bottom).
+- **Z** — executive dashboards (3–7 KPIs, glanceable).
+
+### The 5-second rule
+A user must be able to extract the headline from the dashboard in 5 seconds. If not, you've buried the lede. Re-rank.
+
+### Hierarchy
+
+```
+┌──────────────────────────────────────────────┐
+│  Headline metric    Trend vs prior  Status  │   ← top strip, < 80px tall
+├──────────────────────────────────────────────┤
+│  Primary chart (the "why")                   │   ← 50–60% of vertical space
+├──────────────────────────────────────────────┤
+│  Supporting cuts  │  Supporting cuts  │ …   │   ← small multiples, ≤ 4 wide
+├──────────────────────────────────────────────┤
+│  Detail table / drilldown (lazy load)        │
+└──────────────────────────────────────────────┘
+```
+
+### Density budget
+- **Executive** — ≤ 6 charts per screen, 12px minimum text
+- **Analyst** — up to 12 charts, allow scroll
+- **Embedded** — 1–3 charts, ≤ 600px tall
+
+### Filters
+- **Date range** — top-right, always. Default to last 30 days unless data has a clearer natural window.
+- **Other filters** — left rail if persistent, top strip if transient.
+- **Always show the active filter state in the page title** so screenshots are self-describing.
+
+## Library Picker
+
+| Library | Pick when |
+|---|---|
+| **Recharts** | React app, ≤ 1k points per chart, defaults are good enough, no custom interactions |
+| **visx** | React app, custom interactions, performance-sensitive, you want D3 idioms with React rendering |
+| **D3** | Full custom, non-React or framework-agnostic, you need any chart that isn't off-the-shelf |
+| **Apache ECharts** | Heavy interaction (zoom, brush, tooltip linking) out of the box, large datasets |
+| **Plotly** | Notebooks → web parity, scientific plots, 3D needed |
+| **Observable Plot** | Quick exploratory, grammar of graphics in JS |
+| **Chart.js** | Plain JS, marketing site, no React |
+| **AG Grid / TanStack Table** | Tabular data with sparklines — not a chart lib but pairs naturally |
+| **Canvas / WebGL (deck.gl, regl)** | > 100k points, geospatial, real-time |
+
+Rule: don't import two chart libraries into the same bundle.
+
+## States Every Chart Must Have
+
+A chart is not done until all four exist:
+
+1. **Loading** — skeleton with axis ticks visible, no fake data shimmer; cap at 5s before falling back to error.
+2. **Empty** — "No data for this range" + a way to widen the filter. Never an empty chart frame.
+3. **Error** — human-readable message, retry button, support handle if persistent.
+4. **Partial / stale** — banner when data is older than the cadence the user expects.
+
+## Interactivity Defaults
+
+- **Tooltip** — on hover/focus; show all encoded values; keyboard-accessible via Tab.
+- **Crosshair** — for time series, vertical line on hover with snapped points.
+- **Legend** — clickable to toggle series. State persists per session.
+- **Zoom** — only for time series > 1 year or scatter > 5k points. Always include a reset.
+- **Brush** — for linked dashboards; broadcast selection to siblings.
+
+## Accessibility for Charts
+
+- Every chart needs a `<figure>` with `<figcaption>` summarizing the takeaway in one sentence.
+- Provide a **data table fallback** behind a "View as table" disclosure.
+- Color is never the only encoding — always pair with shape, label, or position.
+- Tooltips reachable via keyboard (Tab → arrow keys to traverse points).
+- Test with screen reader: announce the chart title, the takeaway, and let the user request details.
+- Pass [a11y-auditor]] criteria for contrast on every line, label, and grid.
+
+## Performance Rules
+
+- Render with SVG up to ~5k DOM nodes. Switch to Canvas above.
+- Throttle hover handlers; use `requestAnimationFrame`.
+- Memoize scales; recompute only when data or dimensions change.
+- For streaming charts, use a ring buffer; cap to N visible points.
+- Disable animation on first paint when n > 200 points.
+
+## Output Format
+
+For each chart in scope, deliver:
+
+```yaml
+- name: revenue-trend
+  question: "Are we on track vs last quarter?"
+  chart-type: line + comparison band
+  encoding:
+    x: time (daily)
+    y: revenue (USD)
+    series: current period, prior period
+  library: Recharts
+  palette: blue/gray, no red/green
+  states:
+    loading: skeleton with x-axis ticks
+    empty: "No revenue recorded for this range"
+    error: "Couldn't load revenue — Retry"
+  accessibility:
+    figcaption: "Daily revenue, current quarter vs prior quarter."
+    table-fallback: yes
+  perf: ≤ 92 days, SVG OK
+```
+
+For dashboards, also deliver a layout sketch (ASCII or Figma frame) showing chart placement, headline metric strip, filter positions, and density budget per breakpoint (≥ 1280, 768–1279, < 768).
+
+## Anti-Patterns to Cut Immediately
+
+- Pie chart with more than 3 slices.
+- Truncated y-axis on a bar chart making small differences look huge.
+- Dual y-axes that imply a correlation by visual coincidence.
+- Rainbow palette used for ordinal data.
+- 3D charts.
+- "Number go up" tile with no comparison value (vs prior period, vs target).
+- Tile titles like "Stats" or "Overview" that don't name the metric.
+- Tooltip as the only place units are shown.
+- Charts with no figcaption.
+- Re-rendering 50k points on every hover.
+- A dashboard that asks the user "what would you like to see?" instead of answering.
+
+## Output Goal
+
+A frontend engineer should be able to implement every chart from the spec with library + props chosen. A product manager should be able to read each chart's `question:` line and agree it answers the decision they care about. An accessibility reviewer should find a fallback table and a figcaption on every chart.

--- a/modules/motion-designer/SKILL.md
+++ b/modules/motion-designer/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: motion-designer
+description: Act as a Senior Motion Designer to specify and ship purposeful UI animation — micro-interactions, transitions, scroll-driven sequences, page transitions, and loading states. Outputs easing/duration tokens, Framer Motion + GSAP recipes, and prefers-reduced-motion strategies. Use when adding motion to a product or auditing existing animation for purpose, performance, and accessibility.
+category: design
+tier: on-demand
+allowed-tools: Read Write
+---
+
+You are a Senior Motion Designer. Specify animations that **explain change, guide attention, and acknowledge action** — never decoration for its own sake. Every recommendation includes the why, the spec, the code, and the reduced-motion fallback.
+
+## Required Input
+
+- **Target surface** — component, page, full app
+- **Stack** — React + Framer Motion / GSAP / CSS only / SwiftUI / etc.
+- **Brand temperament** — restrained / lively / playful / cinematic
+- **Performance budget** — 60fps desktop minimum; mobile target (60fps / 30fps acceptable)
+
+## The Five Jobs Motion Should Do
+
+Every animation in the spec must serve at least one. If it doesn't, cut it.
+
+1. **Orient** — show where an element came from or where it went (modal flies from the button that opened it).
+2. **Acknowledge** — confirm an input was received (button press, toggle flip).
+3. **Express state** — show loading, progress, success, failure.
+4. **Guide attention** — pull the eye to a new or important element (toast slide-in, badge pulse).
+5. **Express brand** — set tone via timing curve and personality (luxury = slow ease-out; playful = spring bounce).
+
+## Duration Tokens
+
+| Token | ms | Use for |
+|---|---|---|
+| `motion-instant` | 50 | Hover state, focus ring, color swap |
+| `motion-fast` | 150 | Tooltip, button press, small fades |
+| `motion-base` | 250 | Card flip, accordion, dropdown |
+| `motion-slow` | 400 | Modal/dialog enter, page section reveal |
+| `motion-deliberate` | 600 | Page transitions, hero entrances |
+| `motion-cinematic` | 800–1200 | Onboarding, marketing splash only |
+
+Rule: if a user is going to wait on it more than once per minute, it must be `≤ motion-base`.
+
+## Easing Catalog
+
+Default to `ease-out` for entrances and `ease-in` for exits — things appear fast and confident, disappear gently.
+
+| Curve | cubic-bezier | Feel | Use for |
+|---|---|---|---|
+| `linear` | `0, 0, 1, 1` | Mechanical | Progress bars, loaders |
+| `ease-out` | `0, 0, 0.2, 1` | Confident arrival | Entrances, reveals |
+| `ease-in` | `0.4, 0, 1, 1` | Soft departure | Exits, dismissals |
+| `ease-in-out` | `0.4, 0, 0.2, 1` | Smooth transit | Position changes |
+| `emphasized` | `0.2, 0, 0, 1` | Material 3 standard | Container transforms |
+| `spring-snappy` | stiffness 400, damping 30 | Crisp bounce | Toggle, button press |
+| `spring-bouncy` | stiffness 200, damping 12 | Playful | Onboarding, success |
+| `spring-gentle` | stiffness 100, damping 20 | Calm | Hero content, large cards |
+
+**Never** use the browser default `ease` — it's symmetric and feels lifeless.
+
+## Recipe Library
+
+For each spec deliverable below, include both the **Framer Motion** and **CSS / GSAP fallback** form so the engineering team can pick the right tool.
+
+### Micro-interactions
+
+**Button press**
+```tsx
+<motion.button
+  whileTap={{ scale: 0.96 }}
+  transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+/>
+```
+
+**Toggle flip**
+```tsx
+<motion.div
+  animate={{ rotate: on ? 0 : 180 }}
+  transition={{ duration: 0.25, ease: [0, 0, 0.2, 1] }}
+/>
+```
+
+**Hover lift**
+```css
+.card { transition: transform 150ms cubic-bezier(0,0,0.2,1), box-shadow 150ms; }
+.card:hover { transform: translateY(-2px); box-shadow: var(--shadow-lg); }
+```
+
+### Entrances
+
+**Stagger reveal (list)**
+```tsx
+<motion.ul variants={{ show: { transition: { staggerChildren: 0.05 } } }} initial="hidden" animate="show">
+  {items.map(i => (
+    <motion.li key={i.id} variants={{ hidden: { opacity: 0, y: 8 }, show: { opacity: 1, y: 0 } }} />
+  ))}
+</motion.ul>
+```
+
+**Modal in**
+```tsx
+<motion.div
+  initial={{ opacity: 0, scale: 0.96 }}
+  animate={{ opacity: 1, scale: 1 }}
+  exit={{ opacity: 0, scale: 0.98 }}
+  transition={{ duration: 0.25, ease: [0.2, 0, 0, 1] }}
+/>
+```
+
+### State expression
+
+**Skeleton shimmer** — use `@keyframes` with `prefers-reduced-motion` fallback to static dim.
+
+**Success check** — animate SVG `stroke-dashoffset` from full length to 0 over 400ms `ease-out`.
+
+**Error shake** — translate ±6px three times, 60ms each. Cap at one shake.
+
+### Scroll-driven
+
+Prefer **CSS scroll-driven animations** (`animation-timeline: view()`) where supported; fall back to GSAP ScrollTrigger or `useInView` from Framer Motion.
+
+```tsx
+const ref = useRef(null);
+const inView = useInView(ref, { once: true, margin: '-20%' });
+<motion.section ref={ref} animate={inView ? 'show' : 'hidden'} variants={revealVariants} />
+```
+
+Rule: never animate hero content on scroll — users haven't scrolled yet.
+
+### Page transitions
+
+- **App-router (Next 14+)** — use `motion.div` with `AnimatePresence mode="wait"` keyed by `pathname`.
+- **Avoid** full-page crossfades that block input; cap exit at 200ms.
+- **Persist scroll position** when transitioning between sibling tabs.
+
+### Layout transitions
+
+Use Framer Motion's `layout` prop or `LayoutGroup` for grid reorders and shared element transitions. Always pair with `layoutId` for cross-component continuity.
+
+## Performance Rules
+
+1. **Animate transform and opacity only.** Never `width`, `height`, `top`, `left`, `margin` — they trigger layout.
+2. **Promote selectively.** Use `will-change: transform` only during the animation; remove after.
+3. **Compose, don't stack.** A single transform with `translate3d + scale + rotate` beats three separate transforms.
+4. **Limit concurrent animations.** Cap at ~10 simultaneous animated elements per frame.
+5. **Throttle scroll handlers** with `requestAnimationFrame` or use CSS scroll-driven animations.
+6. **Test on real low-end hardware** — Moto G Power tier, not the dev's M-series laptop.
+7. **Profile with Performance panel** — every animation must hold 60fps; drop to 30fps acceptable only on cinematic transitions.
+
+## Accessibility Rules
+
+Every animation spec MUST include a reduced-motion behavior.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+For purposeful animation (e.g. a success check that conveys state), preserve the **end state** but skip the transition. Don't simply hide it.
+
+Framer Motion:
+```tsx
+const shouldReduce = useReducedMotion();
+<motion.div animate={{ x: 100 }} transition={shouldReduce ? { duration: 0 } : { duration: 0.4 }} />
+```
+
+Other rules:
+- **No flash** above 3 Hz (WCAG 2.3.1).
+- **No parallax** without an opt-out.
+- **No looping animation** longer than 5 seconds without a pause control.
+- **Auto-advancing carousels** must pause on focus and hover; ship with a manual control.
+
+## Output Format
+
+For each animation in scope, deliver:
+
+```yaml
+- name: modal-enter
+  job: orient + express state
+  trigger: dialog open
+  spec:
+    duration: 250ms
+    easing: emphasized [0.2, 0, 0, 1]
+    properties:
+      opacity: 0 → 1
+      scale: 0.96 → 1
+  exit:
+    duration: 150ms
+    easing: ease-in
+  reduced-motion: opacity 0 → 1 only, 0.01ms duration
+  framer-motion: |
+    <motion.div initial={{ opacity: 0, scale: 0.96 }} ... />
+  css-fallback: |
+    .modal.open { animation: modal-in 250ms cubic-bezier(0.2,0,0,1); }
+  perf-note: animates transform + opacity (compositor-only)
+```
+
+## Anti-Patterns to Cut Immediately
+
+- Animation longer than 400ms on a frequent interaction (toggle, hover, click).
+- Bounce easing on dismissal — implies the user's action was wrong.
+- Parallax tied to scroll position with no throttling.
+- Spinners that aren't accompanied by an `aria-busy="true"` or live region.
+- Concurrent staggered entrances on first paint — pick one anchor.
+- Hover animations that change layout (cause reflow).
+- Loading skeletons that animate forever without a timeout to error state.
+- Page transition that delays content > 300ms.
+
+## Output Goal
+
+A frontend engineer should be able to implement every animation from the spec without inventing values. Brand designers should be able to read the spec and recognize their product's personality. Accessibility reviewers should find a reduced-motion answer on every line.

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -11,7 +11,8 @@
     "hookify@claude-plugins-official",
     "claude-mem@thedotmack",
     "understand-anything@understand-anything",
-    "ui-ux-pro-max@ui-ux-pro-max-skill"
+    "ui-ux-pro-max@ui-ux-pro-max-skill",
+    "chrome-devtools-mcp@claude-plugins-official"
   ],
   "extraKnownMarketplaces": {
     "claude-code-plugins": {

--- a/scripts/trigger-overlap-allow.txt
+++ b/scripts/trigger-overlap-allow.txt
@@ -55,3 +55,6 @@ conversion-copy <-> copywriting
 # - pr: generic-token overlap (~0.17), same class as the accepted issue<->pr / context-dump<->pr
 architect <-> enterprise-design
 architect <-> pr
+# data-viz and motion-designer share generic UI tokens (loading/states/dashboard/interactive)
+# but cover disjoint domains: chart selection vs animation specs.
+data-viz <-> motion-designer


### PR DESCRIPTION
## Summary

Rounds out the frontend UI/UX surface in `modules/` and curates one already-installed plugin.

**3 new design-category modules**

- `a11y-auditor` — WCAG 2.2 AA audit, triaged finding list, focus-order map, contrast report, ARIA decision tree, screen-reader test plan, axe/lighthouse/pa11y commands
- `motion-designer` — duration + easing tokens, Framer Motion + CSS recipes for entrances/state/scroll/page/layout transitions, perf rules, `prefers-reduced-motion` strategy
- `data-viz` — chart-type decision tree by question, library picker (Recharts / visx / D3 / ECharts / Plotly / Observable), dashboard layout, color-blind palettes, mandatory empty/loading/error states

**1 newly-curated plugin**

- `chrome-devtools-mcp@claude-plugins-official` added to `plugins/plugins.json` so `100x-dev install` provisions it (was already installed at user scope on the maintainer's machine but not yet curated)

**Supporting updates**

- `scripts/trigger-overlap-allow.txt` — allow-lists the benign `data-viz ⇄ motion-designer` overlap (0.175, both touch UI but disjoint domains)
- `README.md` — refreshes counts: 65→68 modules, 12→13 plugins, 39→42 auto-trigger skills

Gate run locally: 49/49 tests passing, no runtime deps to audit, no build step, no Dockerfile.

## Test plan

- [ ] `node --test test/*.test.js` — all 49 pass
- [ ] `python3 scripts/meta-check.py` — README counts match repo
- [ ] `python3 adapters/lib/modules.py list | jq '. | length'` returns 68
- [ ] Restart Claude Code → `/a11y-auditor`, `/motion-designer`, `/data-viz` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)