### PR TITLE
fix(windows): migrate adapter to v2 modules/ emit with pruning

### DIFF
--- a/lib/adapters/windows.js
+++ b/lib/adapters/windows.js
@@ -4,27 +4,221 @@ const fs = require('fs')
 const path = require('path')
 const { spawnSync } = require('child_process')
 
-const WORKFLOW_ORDER = [
-  'gate', 'test', 'commit', 'push', 'pr', 'branch', 'launch', 'lint',
-  'security', 'docs', 'issue', 'architect', 'cloud-security',
-  'enterprise-design', 'db', 'fix', 'spec', 'grill', 'techdebt',
-  'context', 'query', 'orchestrate', 'update-claude',
+// ── v2 module emit (pure-JS port of adapters/lib/modules.py emit-claude-code) ──
+// Windows has no bash, so the Node path can't call install.sh/update.sh. This
+// mirrors the Python emitter: parse modules/<slug>/SKILL.md, write Claude Code
+// skills + slash-command aliases, and prune anything we previously emitted that
+// no longer exists — without touching the user's own skills/commands.
+
+const GENERATED_MARKER = '.100x-dev-generated'
+const ALIAS_MARKER = '<!-- 100x-dev generated alias — regenerate, do not edit -->'
+const MANIFEST_NAME = '.100x-dev-manifest.json'
+// Modules removed/merged upstream — cleaned up even for installs that predate the
+// manifest/marker. Safe to trim once installs have cycled through a v2 update.
+const REMOVED_MODULES = new Set(['systems-architect', 'conversion-copy'])
+
+const MODEL_TIER_HINT = {
+  haiku: 'fast / low-cost (mechanical task)',
+  sonnet: 'balanced (moderate reasoning)',
+  opus: 'most capable (deep reasoning)',
+}
+const CATEGORY_ORDER = [
+  'lifecycle', 'quality', 'engineering', 'data', 'design', 'docs', 'marketing', 'uncategorized',
 ]
 
-function copyWorkflowsToClaudeCommands(workflowsDir, commandsDir) {
-  fs.mkdirSync(commandsDir, { recursive: true })
-  for (const file of fs.readdirSync(workflowsDir).filter(f => f.endsWith('.md'))) {
-    const content = fs.readFileSync(path.join(workflowsDir, file), 'utf8')
-    fs.writeFileSync(path.join(commandsDir, file), content + '\n$ARGUMENTS\n')
-  }
-  const dbEnginesDir = path.join(workflowsDir, 'db-engines')
-  if (fs.existsSync(dbEnginesDir)) {
-    const dstDbDir = path.join(commandsDir, 'db-engines')
-    fs.mkdirSync(dstDbDir, { recursive: true })
-    for (const file of fs.readdirSync(dbEnginesDir).filter(f => f.endsWith('.md'))) {
-      fs.copyFileSync(path.join(dbEnginesDir, file), path.join(dstDbDir, file))
+function tierAnnotation(model) {
+  const hint = MODEL_TIER_HINT[(model || '').trim()]
+  return hint ? `_Suggested model tier: ${hint}_` : ''
+}
+
+function shortDescription(desc) {
+  let d = (desc || '').split('. ')[0]
+  if (d.length > 140) d = d.slice(0, 137) + '...'
+  return d
+}
+
+// Mirror modules.py split_frontmatter: simple `key: value` block with indented
+// continuation lines folded into the previous key.
+function parseFrontmatter(text) {
+  if (!text.startsWith('---\n')) return { fm: {}, body: text }
+  const end = text.indexOf('\n---\n', 4)
+  if (end === -1) return { fm: {}, body: text }
+  const block = text.slice(4, end)
+  const body = text.slice(end + 5)
+  const fm = {}
+  let currentKey = null
+  for (const line of block.split('\n')) {
+    if (!line.trim()) continue
+    if (/^\s/.test(line) && currentKey) {
+      fm[currentKey] = `${fm[currentKey]} ${line.trim()}`.trim()
+      continue
+    }
+    const idx = line.indexOf(':')
+    if (idx !== -1) {
+      currentKey = line.slice(0, idx).trim()
+      fm[currentKey] = line.slice(idx + 1).trim()
     }
   }
+  return { fm, body }
+}
+
+function listModules(modulesDir) {
+  const out = []
+  let entries = []
+  try {
+    entries = fs.readdirSync(modulesDir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const skillMd = path.join(modulesDir, entry.name, 'SKILL.md')
+    if (!fs.existsSync(skillMd)) continue // skips shared-reference dirs like _lib/
+    const { fm, body } = parseFrontmatter(fs.readFileSync(skillMd, 'utf8'))
+    out.push({
+      slug: entry.name,
+      category: fm.category || 'uncategorized',
+      tier: fm.tier || 'on-demand',
+      slash: (fm.slash_command || '').replace(/^\//, ''),
+      description: fm.description || '',
+      model: fm.model || '',
+      fm,
+      body,
+    })
+  }
+  out.sort((a, b) =>
+    (a.tier !== 'core') - (b.tier !== 'core') ||
+    a.category.localeCompare(b.category) ||
+    a.slug.localeCompare(b.slug))
+  return out
+}
+
+function renderCommandAlias(m) {
+  const lines = ['---', `description: ${shortDescription(m.description)}`]
+  if (m.model) lines.push(`model: ${m.model}`)
+  const allowed = (m.fm['allowed-tools'] || '').trim()
+  if (allowed) lines.push(`allowed-tools: ${allowed}`)
+  if (m.body.includes('$ARGUMENTS') || m.body.includes('$1')) lines.push('argument-hint: [arguments]')
+  lines.push('---', '', ALIAS_MARKER, '', `Use the \`${m.fm.name || m.slug}\` skill.`, '', '$ARGUMENTS', '')
+  return lines.join('\n')
+}
+
+function readManifest(skillsDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(skillsDir, MANIFEST_NAME), 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+// Emit all modules as Claude Code skills + slash aliases, then prune stale ones.
+// Returns { skills, commands, prunedSkills, prunedCommands }.
+function emitClaudeModules(modulesDir, skillsDir, commandsDir) {
+  fs.mkdirSync(skillsDir, { recursive: true })
+  fs.mkdirSync(commandsDir, { recursive: true })
+
+  const prev = readManifest(skillsDir)
+  const prevSkills = new Set(prev.skills || [])
+  const prevCmds = new Set(prev.commands || [])
+
+  const modules = listModules(modulesDir)
+  const currentSkills = []
+  const currentCmds = []
+
+  for (const m of modules) {
+    const target = path.join(skillsDir, m.slug)
+    fs.rmSync(target, { recursive: true, force: true })
+    fs.cpSync(path.join(modulesDir, m.slug), target, { recursive: true })
+    fs.writeFileSync(path.join(target, GENERATED_MARKER),
+      'Generated by 100x-dev from modules/<slug>/SKILL.md. Regenerate instead of editing here.\n')
+    currentSkills.push(m.slug)
+    if (m.slash) {
+      fs.writeFileSync(path.join(commandsDir, `${m.slash}.md`), renderCommandAlias(m))
+      currentCmds.push(m.slash)
+    }
+  }
+
+  const curSkillSet = new Set(currentSkills)
+  const curCmdSet = new Set(currentCmds)
+
+  // Prune skills we previously emitted / marked / shipped-as-removed that are gone now.
+  const orphanSkills = new Set([...prevSkills, ...REMOVED_MODULES].filter(s => !curSkillSet.has(s)))
+  for (const child of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+    if (child.isDirectory() && !curSkillSet.has(child.name) &&
+        fs.existsSync(path.join(skillsDir, child.name, GENERATED_MARKER))) {
+      orphanSkills.add(child.name)
+    }
+  }
+  let prunedSkills = 0
+  for (const slug of orphanSkills) {
+    const p = path.join(skillsDir, slug)
+    const ours = fs.existsSync(path.join(p, GENERATED_MARKER)) || prevSkills.has(slug) || REMOVED_MODULES.has(slug)
+    if (fs.existsSync(p) && ours) { fs.rmSync(p, { recursive: true, force: true }); prunedSkills++ }
+  }
+
+  // Prune slash-command aliases we previously wrote (marker-guarded).
+  let prunedCommands = 0
+  for (const name of prevCmds) {
+    if (curCmdSet.has(name)) continue
+    const f = path.join(commandsDir, `${name}.md`)
+    try {
+      if (fs.existsSync(f) && fs.readFileSync(f, 'utf8').includes(ALIAS_MARKER)) {
+        fs.unlinkSync(f); prunedCommands++
+      }
+    } catch { /* ignore */ }
+  }
+
+  fs.writeFileSync(path.join(skillsDir, MANIFEST_NAME),
+    JSON.stringify({ skills: currentSkills.slice().sort(), commands: currentCmds.slice().sort() }, null, 2) + '\n')
+
+  return { skills: currentSkills.length, commands: currentCmds.length, prunedSkills, prunedCommands }
+}
+
+const HEADER =
+  '# 100x Dev — Modules\n' +
+  '# Generated by 100x-dev (https://github.com/rajitsaha/100x-dev)\n' +
+  '# Source of truth: modules/<slug>/SKILL.md. Edit there and regenerate.\n\n'
+
+function categorySortKey(c) {
+  const i = CATEGORY_ORDER.indexOf(c)
+  return i === -1 ? CATEGORY_ORDER.length : i
+}
+
+function emitIndex(modules) {
+  const byCat = {}
+  for (const m of modules) (byCat[m.category] = byCat[m.category] || []).push(m)
+  const lines = []
+  for (const cat of Object.keys(byCat).sort((a, b) => categorySortKey(a) - categorySortKey(b))) {
+    lines.push(`**${cat.charAt(0).toUpperCase() + cat.slice(1)}** (${byCat[cat].length}):`)
+    for (const m of byCat[cat]) {
+      const slash = m.slash ? ` \`/${m.slash}\`` : ''
+      const tier = tierAnnotation(m.model)
+      lines.push(`- \`${m.slug}\`${slash} — ${shortDescription(m.description)}${tier ? ' ' + tier : ''}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n').replace(/\s+$/, '') + '\n'
+}
+
+// Single-file combined config (port of modules.py render_concat): inline core
+// module bodies + an index of on-demand modules. Used for .cursorrules/AGENTS.md/etc.
+function generateCombinedConfig(modulesDir) {
+  const modules = listModules(modulesDir)
+  const core = modules.filter(m => m.tier === 'core')
+  const onDemand = modules.filter(m => m.tier !== 'core')
+  const out = [HEADER, '## Core modules (always-on)\n']
+  core.sort((a, b) => categorySortKey(a.category) - categorySortKey(b.category) || a.slug.localeCompare(b.slug))
+  for (const m of core) {
+    out.push(`---\n\n## ${m.slug}\n`)
+    if (m.slash) out.push(`_Slash command: \`/${m.slash}\`_\n`)
+    const tier = tierAnnotation(m.model)
+    if (tier) out.push(`${tier}\n`)
+    out.push(m.body.replace(/^\n+/, '').replace(/\s+$/, '') + '\n\n')
+  }
+  out.push('---\n\n## On-demand modules (invoke by name)\n\n')
+  out.push('These load only when triggered. Ask Claude to use the relevant module by name when the situation matches.\n\n')
+  out.push(emitIndex(onDemand))
+  return out.join('')
 }
 
 function scaffoldClaudeMd(projectPath) {
@@ -37,7 +231,7 @@ function scaffoldClaudeMd(projectPath) {
   const projectName = path.basename(path.resolve(projectPath))
   fs.writeFileSync(path.join(projectPath, 'CLAUDE.md'), `# ${projectName} — Project Instructions
 
-<!-- Generated by 100x-dev. Fill in the sections below so workflows like /db, /gate, /launch have project context. -->
+<!-- Generated by 100x-dev. Fill in the sections below so modules like /db, /gate, /launch have project context. -->
 
 ## Project
 
@@ -123,21 +317,6 @@ function mergePluginsJson(pluginsFile, settingsFile) {
   fs.writeFileSync(stateFile, JSON.stringify({ managed: [...desiredSet].sort() }, null, 2))
 }
 
-function generateCombinedWorkflows(workflowsDir) {
-  const lines = [
-    '# 100x Dev Workflows',
-    '# Generated by 100x-dev (https://github.com/rajitsaha/100x-dev)',
-    '',
-  ]
-  for (const name of WORKFLOW_ORDER) {
-    const file = path.join(workflowsDir, `${name}.md`)
-    if (fs.existsSync(file)) {
-      lines.push('---', '', fs.readFileSync(file, 'utf8').trimEnd(), '')
-    }
-  }
-  return lines.join('\n')
-}
-
 function addTrackedProject(projectPath, trackedFile) {
   fs.mkdirSync(path.dirname(trackedFile), { recursive: true })
   const existing = fs.existsSync(trackedFile)
@@ -155,17 +334,21 @@ function writeAdapter(content, outputFile) {
 }
 
 function installGlobalWindows(installDir) {
-  const { claudeCommandsDir, claudeSettingsFile } = require('../platform')
-  copyWorkflowsToClaudeCommands(path.join(installDir, 'workflows'), claudeCommandsDir)
+  const { claudeDir, claudeCommandsDir, claudeSettingsFile } = require('../platform')
+  const skillsDir = path.join(claudeDir, 'skills')
+  const r = emitClaudeModules(path.join(installDir, 'modules'), skillsDir, claudeCommandsDir)
   mergePluginsJson(path.join(installDir, 'plugins', 'plugins.json'), claudeSettingsFile)
-  console.log('✓ Workflows installed to ~/.claude/commands/')
+  const pruned = (r.prunedSkills || r.prunedCommands)
+    ? ` (pruned ${r.prunedSkills} stale skill(s), ${r.prunedCommands} stale alias(es))`
+    : ''
+  console.log(`✓ ${r.skills} skills + ${r.commands} slash aliases installed to ~/.claude/${pruned}`)
   console.log('✓ Plugins merged into ~/.claude/settings.json')
   console.log('\nNext: cd into a project and run  100x-dev init  to set it up.')
 }
 
 function initProjectWindows(installDir, projectPath) {
   const { trackedProjectsFile } = require('../platform')
-  const workflowsDir = path.join(installDir, 'workflows')
+  const modulesDir = path.join(installDir, 'modules')
   const absProject = path.resolve(projectPath)
   const readline = require('readline')
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
@@ -197,7 +380,7 @@ function initProjectWindows(installDir, projectPath) {
   }
 
   function applyAdapters() {
-    const combined = generateCombinedWorkflows(workflowsDir)
+    const combined = generateCombinedConfig(modulesDir)
     if (selected.claude)      scaffoldClaudeMd(absProject)
     if (selected.cursor)      writeAdapter(combined, path.join(absProject, '.cursorrules'))
     if (selected.codex)       writeAdapter(combined, path.join(absProject, 'AGENTS.md'))
@@ -231,10 +414,14 @@ function updateWindows(installDir, checkOnly) {
 }
 
 module.exports = {
-  copyWorkflowsToClaudeCommands,
+  parseFrontmatter,
+  shortDescription,
+  listModules,
+  renderCommandAlias,
+  emitClaudeModules,
+  generateCombinedConfig,
   scaffoldClaudeMd,
   mergePluginsJson,
-  generateCombinedWorkflows,
   addTrackedProject,
   installGlobalWindows,
   initProjectWindows,

--- a/test/windows-adapters.test.js
+++ b/test/windows-adapters.test.js
@@ -6,10 +6,10 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const {
-  copyWorkflowsToClaudeCommands,
+  emitClaudeModules,
   scaffoldClaudeMd,
   mergePluginsJson,
-  generateCombinedWorkflows,
+  generateCombinedConfig,
   addTrackedProject,
 } = require('../lib/adapters/windows')
 
@@ -17,24 +17,60 @@ function makeTmpDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), '100x-test-'))
 }
 
-test('copyWorkflowsToClaudeCommands copies .md files and appends $ARGUMENTS', () => {
-  const src = makeTmpDir()
-  const dst = makeTmpDir()
-  fs.writeFileSync(path.join(src, 'gate.md'), '# Gate\ncontent')
-  copyWorkflowsToClaudeCommands(src, dst)
-  const content = fs.readFileSync(path.join(dst, 'gate.md'), 'utf8')
-  assert.ok(content.includes('# Gate'))
-  assert.ok(content.includes('$ARGUMENTS'))
+// Build a fake modules/ dir: each entry is { slug, frontmatter, body }.
+function fakeModules(dir, mods) {
+  for (const m of mods) {
+    const md = path.join(dir, m.slug)
+    fs.mkdirSync(md, { recursive: true })
+    const fm = Object.entries(m.fm || {}).map(([k, v]) => `${k}: ${v}`).join('\n')
+    fs.writeFileSync(path.join(md, 'SKILL.md'), `---\n${fm}\n---\n\n${m.body || 'body'}\n`)
+  }
+}
+
+test('emitClaudeModules writes skills + slash aliases from modules/', () => {
+  const modulesDir = makeTmpDir(), skills = makeTmpDir(), commands = makeTmpDir()
+  fakeModules(modulesDir, [
+    { slug: 'gate', fm: { name: 'gate', description: 'Quality gate.', slash_command: '/gate' } },
+    { slug: 'copywriting', fm: { name: 'copywriting', description: 'Write copy.' } }, // no slash
+    { slug: '_lib', fm: {}, body: '' }, // shared-ref dir — but has SKILL.md here; skip via missing? keep simple
+  ])
+  // _lib in the real repo has no SKILL.md; emulate that:
+  fs.rmSync(path.join(modulesDir, '_lib', 'SKILL.md'))
+
+  const r = emitClaudeModules(modulesDir, skills, commands)
+  assert.equal(r.skills, 2, 'two real modules emitted, _lib skipped')
+  assert.ok(fs.existsSync(path.join(skills, 'gate', 'SKILL.md')))
+  assert.ok(fs.existsSync(path.join(skills, 'gate', '.100x-dev-generated')), 'marker written')
+  assert.ok(fs.existsSync(path.join(commands, 'gate.md')), 'slash alias written')
+  assert.ok(!fs.existsSync(path.join(commands, 'copywriting.md')), 'no alias without slash_command')
+  const manifest = JSON.parse(fs.readFileSync(path.join(skills, '.100x-dev-manifest.json'), 'utf8'))
+  assert.deepEqual(manifest.skills, ['copywriting', 'gate'])
+  assert.deepEqual(manifest.commands, ['gate'])
 })
 
-test('copyWorkflowsToClaudeCommands copies db-engines subdir', () => {
-  const src = makeTmpDir()
-  const dst = makeTmpDir()
-  const dbDir = path.join(src, 'db-engines')
-  fs.mkdirSync(dbDir)
-  fs.writeFileSync(path.join(dbDir, 'postgres.md'), '# Postgres')
-  copyWorkflowsToClaudeCommands(src, dst)
-  assert.ok(fs.existsSync(path.join(dst, 'db-engines', 'postgres.md')))
+test('emitClaudeModules prunes removed modules but keeps user-authored skills/commands', () => {
+  const modulesDir = makeTmpDir(), skills = makeTmpDir(), commands = makeTmpDir()
+  fakeModules(modulesDir, [{ slug: 'gate', fm: { name: 'gate', description: 'Quality gate.', slash_command: '/gate' } }])
+
+  // Pre-existing: a merged-away module (in REMOVED_MODULES, no marker), a user skill, a user command.
+  fs.mkdirSync(path.join(skills, 'systems-architect'))
+  fs.writeFileSync(path.join(skills, 'systems-architect', 'SKILL.md'), 'old')
+  fs.mkdirSync(path.join(skills, 'my-skill'))
+  fs.writeFileSync(path.join(skills, 'my-skill', 'SKILL.md'), 'mine')
+  fs.writeFileSync(path.join(commands, 'my-cmd.md'), 'mine')
+
+  const r = emitClaudeModules(modulesDir, skills, commands)
+  assert.ok(r.prunedSkills >= 1)
+  assert.ok(!fs.existsSync(path.join(skills, 'systems-architect')), 'removed module pruned')
+  assert.ok(fs.existsSync(path.join(skills, 'my-skill')), 'user skill kept')
+  assert.ok(fs.existsSync(path.join(commands, 'my-cmd.md')), 'user command kept')
+
+  // A future-removed module tracked only via manifest/marker is pruned on re-run.
+  fs.mkdirSync(path.join(skills, 'ghost'))
+  fs.writeFileSync(path.join(skills, 'ghost', 'SKILL.md'), 'x')
+  fs.writeFileSync(path.join(skills, 'ghost', '.100x-dev-generated'), 'gen')
+  emitClaudeModules(modulesDir, skills, commands)
+  assert.ok(!fs.existsSync(path.join(skills, 'ghost')), 'marker-tagged orphan pruned')
 })
 
 test('scaffoldClaudeMd writes CLAUDE.md with project name', () => {
@@ -100,12 +136,17 @@ test('mergePluginsJson removes a dropped managed plugin but keeps user plugins',
   assert.equal(enabled['user-only'], true, 'user-managed plugin preserved')
 })
 
-test('generateCombinedWorkflows concatenates gate before commit', () => {
-  const workflowsDir = makeTmpDir()
-  fs.writeFileSync(path.join(workflowsDir, 'gate.md'), '# Gate')
-  fs.writeFileSync(path.join(workflowsDir, 'commit.md'), '# Commit')
-  const result = generateCombinedWorkflows(workflowsDir)
-  assert.ok(result.indexOf('# Gate') < result.indexOf('# Commit'))
+test('generateCombinedConfig inlines core module bodies and indexes on-demand ones', () => {
+  const modulesDir = makeTmpDir()
+  fakeModules(modulesDir, [
+    { slug: 'gate', fm: { name: 'gate', category: 'quality', tier: 'core', slash_command: '/gate', description: 'Quality gate.' }, body: 'GATE BODY' },
+    { slug: 'copywriting', fm: { name: 'copywriting', category: 'marketing', tier: 'on-demand', description: 'Write copy.' }, body: 'COPY BODY' },
+  ])
+  const result = generateCombinedConfig(modulesDir)
+  assert.ok(result.includes('100x Dev — Modules'), 'has header')
+  assert.ok(result.includes('GATE BODY'), 'core body inlined')
+  assert.ok(!result.includes('COPY BODY'), 'on-demand body not inlined')
+  assert.ok(result.includes('`copywriting`'), 'on-demand module indexed')
 })
 
 test('addTrackedProject writes path to file', () => {


### PR DESCRIPTION
Fixes #54.

## Problem
`lib/adapters/windows.js` was still on the pre-v2 `workflows/` layout — it read a non-existent `installDir/workflows`, so on Windows `100x-dev install`/`init`/`update` threw `ENOENT` and emitted no skills/commands.

## Fix
Rewrote the adapter as a **pure-JS port of `adapters/lib/modules.py emit-claude-code`** (no Python/bash dependency, so it works in native Windows Node):
- Walks `modules/<slug>/SKILL.md`, parses frontmatter, writes Claude Code skills + slash-command aliases with the generation marker.
- Writes a manifest and **prunes** skills/aliases it previously emitted that no longer exist (manifest + marker + `REMOVED_MODULES`) — never touching the user's own skills/commands.
- `generateCombinedConfig` (replaces `generateCombinedWorkflows`) builds the single-file config from `modules/` (core bodies inlined + on-demand index) — fixes the project `init` path too.
- Drops `WORKFLOW_ORDER` and `copyWorkflowsToClaudeCommands`.
- `mergePluginsJson` keeps the add/remove parity from #53.

## Verification
- **Byte-for-byte identical to the Python emitter** — verified `diff -rq` on command aliases, skill trees, and the manifest after running both against the real `modules/` (66 skills + 26 aliases, `enterprise-design` present, `systems-architect`/`conversion-copy` gone).
- `npm run check` — 57/57 tests, meta-check green. `test/windows-adapters.test.js` rewritten for the `modules/`-based emit (incl. prune + user-file preservation).

## Acceptance criteria (#54)
- [x] Windows install emits all current `modules/` as skills + slash aliases (no `workflows/` reference)
- [x] Windows update prunes skills/aliases for removed/merged modules without touching user-authored ones
- [x] `WORKFLOW_ORDER` removed
- [x] `test/windows-adapters.test.js` updated to cover the `modules/`-based emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
