### PR TITLE
design(brand): leverage logo — small effort, 100× outcome

### DIFF
--- a/assets/100xprism-hero.svg
+++ b/assets/100xprism-hero.svg
@@ -9,16 +9,17 @@
   <rect width="1200" height="420" rx="20" fill="url(#bg)"/>
   <rect x="0.5" y="0.5" width="1199" height="419" rx="20" fill="none" stroke="#232a31"/>
 
-  <!-- prism motif -->
-  <g transform="translate(96,120)">
-    <rect x="0" y="86" width="118" height="9" rx="4.5" fill="#e7edf3"/>
-    <polygon points="150,18 220,182 80,182" fill="#cfd8e3" fill-opacity="0.07" stroke="#cfd8e3" stroke-width="6" stroke-linejoin="round"/>
-    <g stroke-width="8" stroke-linecap="round">
-      <line x1="172" y1="92" x2="300" y2="34"  stroke="#ff5c5c"/>
-      <line x1="172" y1="92" x2="300" y2="63"  stroke="#ffa23d"/>
-      <line x1="172" y1="92" x2="300" y2="92"  stroke="#ffe14d"/>
-      <line x1="172" y1="92" x2="300" y2="121" stroke="#3ddc84"/>
-      <line x1="172" y1="92" x2="300" y2="150" stroke="#3da9ff"/>
+  <!-- leverage motif: small effort, 100x outcome -->
+  <g transform="translate(96,118)">
+    <line x1="70" y1="190" x2="212" y2="190" stroke="#8b97a3" stroke-width="5" stroke-linecap="round" opacity="0.4"/>
+    <polygon points="150,96 182,188 118,188" fill="#aeb9c4" fill-opacity="0.10" stroke="#aeb9c4" stroke-width="6" stroke-linejoin="round"/>
+    <line x1="8" y1="146" x2="304" y2="58" stroke="#aeb9c4" stroke-width="11" stroke-linecap="round"/>
+    <path d="M22 100 V126" stroke="#ff8a3d" stroke-width="5" fill="none" stroke-linecap="round"/>
+    <path d="M12 116 l10 12 l10 -12" stroke="#ff8a3d" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="22" cy="140" r="10" fill="#ff8a3d"/>
+    <g transform="translate(244,26)">
+      <rect width="78" height="48" rx="12" fill="#3ddc84"/>
+      <text x="39" y="33" text-anchor="middle" font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="27" font-weight="800" fill="#06251a">100×</text>
     </g>
   </g>
 

--- a/assets/100xprism-logo.svg
+++ b/assets/100xprism-logo.svg
@@ -1,16 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 200" width="120" height="94" role="img" aria-label="100xPrism logo">
-  <title>100xPrism</title>
-  <!-- incoming white beam -->
-  <rect x="6" y="99" width="92" height="8" rx="4" fill="#e7edf3"/>
-  <!-- prism -->
-  <polygon points="128,44 198,164 58,164" fill="#cfd8e3" fill-opacity="0.08" stroke="#cfd8e3" stroke-width="6" stroke-linejoin="round"/>
-  <!-- refracted spectrum -->
-  <g stroke-width="7" stroke-linecap="round">
-    <line x1="150" y1="104" x2="250" y2="58"  stroke="#ff5c5c"/>
-    <line x1="150" y1="104" x2="250" y2="76"  stroke="#ffa23d"/>
-    <line x1="150" y1="104" x2="250" y2="94"  stroke="#ffe14d"/>
-    <line x1="150" y1="104" x2="250" y2="112" stroke="#3ddc84"/>
-    <line x1="150" y1="104" x2="250" y2="130" stroke="#3da9ff"/>
-    <line x1="150" y1="104" x2="250" y2="148" stroke="#a06bff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 200" width="120" height="94" role="img" aria-label="100xPrism logo — small effort, 100x outcome">
+  <title>100xPrism — minimal effort, 100× outcome</title>
+
+  <!-- ground -->
+  <line x1="66" y1="170" x2="190" y2="170" stroke="#8b97a3" stroke-width="4" stroke-linecap="round" opacity="0.45"/>
+
+  <!-- fulcrum -->
+  <polygon points="150,98 176,168 124,168" fill="#8b97a3" fill-opacity="0.16" stroke="#8b97a3" stroke-width="5" stroke-linejoin="round"/>
+
+  <!-- lever beam: pivots on the fulcrum — effort end (left) low, outcome end (right) lifted high -->
+  <line x1="26" y1="134" x2="226" y2="66" stroke="#5b6b7a" stroke-width="9" stroke-linecap="round"/>
+
+  <!-- small effort: a light press down on the long arm -->
+  <path d="M33 104 V124" stroke="#ff8a3d" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+  <path d="M27 117 l6 8 l6 -8" stroke="#ff8a3d" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="33" cy="132" r="7.5" fill="#ff8a3d"/>
+
+  <!-- big outcome: the 100x badge, lifted -->
+  <g transform="translate(192,32)">
+    <rect width="60" height="38" rx="10" fill="#3ddc84"/>
+    <text x="30" y="26" text-anchor="middle" font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#06251a">100×</text>
   </g>
 </svg>


### PR DESCRIPTION
Replaces the prism mark (which showed the *mechanism* — one config → many tools) with a **lever**: a small effort lifting a big `100×`. Conveys the actual value — *less effort, more outcome*.

Applied to both `assets/100xprism-logo.svg` (README mark) and `assets/100xprism-hero.svg` (banner motif). Vector, works light/dark, renders crisp at favicon size.

All checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)