### PR TITLE
feat(token-tooling): join value to cost in the token dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ This is a first, deliberately humble attempt to **measure both — and to make i
 100x-value    # value economics  — what actually shipped for that spend
 ```
 
-- **`100x-tokens`** — one offline, machine-wide dashboard at a single URL: the input/output/cache split, a startup-bloat meter, an *estimated* code-vs-logs-vs-output composition, and $ cost — by project, model, and day.
-- **`100x-value`** — tokens measure *cost*; this measures *value*: the features actually shipped for that spend, read side by side.
+- **`100x-tokens`** — one offline, machine-wide dashboard at a single URL: the input/output/cache split, a startup-bloat meter, an *estimated* code-vs-logs-vs-output composition, and $ cost — by project, model, and day. It auto-refreshes every 5 minutes, so a tab left open never goes stale.
+- **`100x-value`** — tokens measure *cost*; this measures *value*. Run it in a repo and it summarizes what shipped (CHANGELOG + the unreleased commits on top of the last release) **and registers that repo** in a central store at `~/.100xprism/value.json`. The dashboard then renders a **"Value — cost vs. what shipped"** panel **in the same URL** — each release's *estimated* token cost (attributed by date window) sitting right next to what it delivered. Cost and value, one screen.
 
 Full guide: [docs/token-optimization.md](docs/token-optimization.md).
 

--- a/docs/superpowers/specs/2026-06-21-value-cost-dashboard-unification-design.md
+++ b/docs/superpowers/specs/2026-06-21-value-cost-dashboard-unification-design.md
@@ -1,0 +1,182 @@
+# Value × Cost — unified dashboard
+
+**Date:** 2026-06-21
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+The README promises:
+
+> `100x-value` — tokens measure *cost*; this measures *value*: the features
+> actually shipped **for that spend**, read side by side.
+
+The current `scripts/value-report.py` does **not** deliver this. It is a
+CHANGELOG + git summarizer that reads **zero** token data — its own docstring
+says "to read *alongside* token cost." Cost and value never touch: no shared
+key, no per-release cost, no side-by-side. The "for that spend" half is
+unimplemented.
+
+Two further defects:
+
+1. **Tag double-count.** `git_summary()` derives the "unreleased" boundary from
+   `git describe --tags`. When the CHANGELOG moves ahead of git tags (latest tag
+   `v2.3.1`, but CHANGELOG documents `v2.3.2`/`v2.3.3` as shipped), the already
+   released commits show up *both* as "Shipped" (from CHANGELOG) and as
+   "Unreleased work" (from git). Same work counted twice.
+2. **Stale dashboard.** `100x-tokens` builds its data once at startup and never
+   refreshes unless you click Rescan; a long-lived tab silently goes stale.
+
+## Goals
+
+- A single URL (`100x-tokens`, `127.0.0.1:8787`) shows **cost next to value**.
+- Value + cost persisted in **one central, machine-wide store**.
+- Fix the tag double-count so the ledger is honest.
+- Dashboard auto-refreshes so it stops going stale.
+- Update the README so the promise matches reality.
+
+## Non-goals
+
+- No exact per-feature cost. Attribution is date-windowed and **labelled an
+  estimate**, like the existing composition meter.
+- No browser/E2E tests for the new panel.
+- No change to how transcripts are parsed or how token cost rates are set.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Repo discovery | **Hybrid** — registry is source of truth; dashboard also auto-discovers git repos from transcript labels |
+| Central store | `~/.100xprism/value.json` |
+| Cost attribution | Shown per release, **labelled "estimate — attributed by date window"** |
+| Freshness | **Auto-refresh every 5 min** (server rebuild thread + client poll) |
+
+## Architecture
+
+### Components
+
+1. **`scripts/_shipped.py`** *(new shared helper)* — single source of truth for
+   "what shipped" parsing. Exposes:
+   - `parse_changelog(path, limit) -> [release]` (moved from `value-report.py`)
+   - `git_summary(repo) -> {since, count, buckets}` with the **fixed boundary**
+   - `repo_value(repo_path, versions) -> {name, label, releases, unreleased}` —
+     the full per-repo value snapshot, including the precomputed dashboard
+     `label` (join key)
+   - `project_label_for_path(abs_path) -> str` — replicates the dashboard's
+     path→label mangling so registry entries join correctly
+   - Store I/O: `load_store()`, `save_repo(entry)`, `STORE_PATH`
+
+2. **`scripts/value-report.py`** *(slimmed)* — CLI front end. Calls
+   `_shipped.repo_value()`, prints the report (unchanged output), and writes the
+   repo's snapshot to the central store (registry). Keeps `--versions`, repo arg.
+
+3. **`scripts/token-dashboard.py`** *(extended)* —
+   - `build()` gains a `by_project_day` aggregate: `{label: {day: token-dict}}`.
+   - New `value_panel(data)` builds the cost↔value join from the store +
+     `by_project_day`.
+   - `/api/value` route returns the joined panel data; the page renders a
+     **"Value — cost vs. what shipped"** section.
+   - Background daemon thread rebuilds `Handler.data` every 300 s.
+   - Client `setInterval` polls `/api/data` every 5 min and re-renders, with an
+     "updated HH:MM" stamp.
+
+### Data flow
+
+```
+100x-value (in repo)
+  └─ _shipped.repo_value(cwd) ──► print report
+                              └─► save_repo() ──► ~/.100xprism/value.json
+                                                        │
+100x-tokens (singleton server)                          │
+  ├─ build() ──► by_project_day (cost per label × day)  │
+  ├─ load_store() ◄─────────────────────────────────────┘
+  ├─ auto-discover git repos from transcript labels (source:"auto",
+  │    registry entries win on conflict)
+  └─ value_panel(): for each repo release, sum its label's cost across
+       [prev_release_date … release_date]  ──►  /api/value  ──►  panel
+```
+
+### The cost↔value join
+
+- Map a repo's store `label` to the dashboard's `by_project_day` key (identical
+  mangling, so they match).
+- Releases are date-sorted (newest first). For release *i* with date `d_i` and
+  predecessor date `d_{i-1}`, estimated cost = Σ cost of that label over days in
+  `(d_{i-1}, d_i]`. The newest release's window opens at the previous release's
+  date; **unreleased** = days after the newest release date through today.
+- Releases with no parsable date are listed without a cost figure.
+- The whole panel is captioned **"estimate — attributed by date window"**.
+
+### Tag double-count fix
+
+`git_summary()` boundary becomes the **most recent `chore(release):` commit**
+(`git log --grep='^chore(release)' -n1 --pretty=%H`), with `git describe --tags`
+as fallback when no such commit exists. Commits after that boundary are the only
+ones reported as unreleased, so changelogged versions no longer reappear.
+
+### Central store schema — `~/.100xprism/value.json`
+
+```json
+{
+  "version": 1,
+  "repos": {
+    "/abs/path/to/repo": {
+      "name": "repo",
+      "label": "~/personal/github/repo",
+      "scanned": "2026-06-21T12:00:00",
+      "source": "registry",
+      "releases": [
+        {"version": "2.3.3", "date": "2026-06-21",
+         "sections": {"Added": ["…"], "Changed": ["…"]}, "items": 3}
+      ],
+      "unreleased": {"count": 7, "buckets": {"feat": 2, "docs": 2, "other": 3}}
+    }
+  }
+}
+```
+
+Writes are last-writer-wins per repo key. On dashboard rebuild, an `auto` entry
+never overwrites a `registry` entry for the same path.
+
+### Auto-refresh
+
+- **Server:** daemon thread loops `Handler.data = build(verbose=False)` every
+  300 s. `build()` is incremental (mtime/size cache), so the steady-state cost is
+  near zero. Guard with a lock so a manual `/api/refresh` and the timer don't
+  race.
+- **Client:** `setInterval(load, 300000)` re-fetches `/api/data` (+ `/api/value`)
+  and re-renders. Header shows `updated HH:MM:SS`. Manual Rescan button stays.
+
+## Error handling
+
+- Missing `~/.100xprism/` → created on first `save_repo()`. Missing/corrupt
+  `value.json` → treated as empty store, dashboard renders without the panel
+  (no crash).
+- Repo with no CHANGELOG and no tags → `repo_value` returns empty releases;
+  `100x-value` prints the existing "No CHANGELOG.md found" message.
+- A label in the store with no matching `by_project_day` cost → release rows
+  render with value but a blank `$` cell (no cost data for that window).
+- Git/subprocess failure → `git_summary` returns `None` (existing behavior).
+
+## Testing (`scripts/test_value.py`, `unittest`)
+
+1. `parse_changelog` — multi-release fixture, section/bullet counts.
+2. **Tag-lag regression** — CHANGELOG ahead of tags + a `chore(release)` commit
+   ⇒ no released version appears as unreleased.
+3. `chore(release)` boundary selection (and tag fallback when absent).
+4. Date-window cost join — synthetic store + synthetic `by_project_day`
+   ⇒ each release gets the expected windowed cost; unreleased gets the tail.
+5. Store round-trip — `save_repo` then `load_store`; `auto` does not clobber
+   `registry`.
+6. `project_label_for_path` matches `token-dashboard.project_label` for the same
+   path.
+
+## Modules touched
+
+| File | Change |
+|---|---|
+| `scripts/_shipped.py` | **new** — shared changelog/git/store helper |
+| `scripts/value-report.py` | slim to CLI + registry write; use helper |
+| `scripts/token-dashboard.py` | `by_project_day`, `/api/value`, value panel, refresh thread + client poll |
+| `scripts/test_value.py` | **new** — unittest coverage above |
+| `README.md` | rewrite "Token & value economics" to describe the unified dashboard |
+| `shell/aliases.sh` | unchanged (aliases already point at both scripts) |

--- a/docs/token-optimization.md
+++ b/docs/token-optimization.md
@@ -139,14 +139,23 @@ treat it as directional. It's the closest you can get without re-tokenizing.
 ### Value, not just cost: `value-report.py`
 
 Tokens measure *cost*; they can't tell you what you *shipped*. `value-report.py`
-fills that gap from a repo's `CHANGELOG.md` + recent git history:
+fills that gap from a repo's `CHANGELOG.md` + the unreleased commits on top of the
+last release (the "unreleased" boundary is the most recent `chore(release):`
+commit, so versions already in the CHANGELOG don't double-count):
 
 ```bash
-100x-value                          # alias → what shipped in the current repo
+100x-value                          # what shipped in the current repo — and register it
 python3 scripts/value-report.py /path/to/repo --versions 8
+python3 scripts/value-report.py --no-register   # print only, don't touch the store
 ```
 
-Read it next to `100x-tokens` for a cost-vs-value picture.
+Running it also **registers the repo** in a central store at
+`~/.100xprism/value.json`. The `100x-tokens` dashboard reads that store and renders
+a **"Value — cost vs. what shipped"** panel **in the same URL**: each release's
+*estimated* token cost — that project's spend over the release's date window —
+next to what it delivered. The estimate is directional (attributed by date, not
+billed per feature), like the composition meter. The CLI and the dashboard share
+one parser (`scripts/_shipped.py`), so they never disagree.
 
 ### Other options
 - `npx ccusage@latest` and `npx ccusage@latest blocks --live` — terminal dashboards.

--- a/scripts/_shipped.py
+++ b/scripts/_shipped.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+_shipped.py — shared "what shipped" + central value store.
+
+Single source of truth for the value side of token & value economics, used by
+both `value-report.py` (the CLI) and `token-dashboard.py` (the web UI), so the
+two never drift.
+
+It knows three things:
+
+  1. What a repo SHIPPED — parsed from CHANGELOG.md (Keep a Changelog) and recent
+     git history, bucketed by conventional-commit type. The "unreleased" boundary
+     is the most recent `chore(release):` commit (tag as fallback), so versions
+     already documented in the CHANGELOG don't double-count as unreleased.
+
+  2. The dashboard's project LABEL for a repo path — the same path→label mangling
+     the token dashboard applies to transcript dirs, so a repo registered by the
+     CLI joins to its token cost in the dashboard.
+
+  3. The central store at ~/.100xprism/value.json — one machine-wide ledger of
+     every repo's value snapshot, written by the CLI (source "registry") and the
+     dashboard's auto-discovery (source "auto"; registry always wins).
+
+Offline, no third-party dependencies.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+
+HOME = os.path.expanduser("~")
+PROJECTS_DIR = os.path.join(HOME, ".claude", "projects")
+
+STORE_DIR = os.path.join(HOME, ".100xprism")
+STORE_PATH = os.path.join(STORE_DIR, "value.json")
+STORE_VERSION = 1
+
+VERSION_RE = re.compile(r"^##\s*\[([^\]]+)\]\s*(?:[—-]\s*(.+))?$")
+SECTION_RE = re.compile(r"^###\s+(.+)$")
+BULLET_RE = re.compile(r"^[-*]\s+(.+)$")
+CC_RE = re.compile(r"^([a-z]+)(?:\([^)]*\))?!?:")
+
+# The dashboard turns a transcript dir like "-Users-rajit-foo-bar" into a label.
+# Mirror that transform here so registry entries share the dashboard's join key.
+_HOME_DASH = HOME.replace("/", "-") + "-"  # e.g. "-Users-rajit-"
+
+
+# ----------------------------------------------------------------- labels
+
+def _label_from_dirname(dirname):
+    return dirname.replace(_HOME_DASH, "~/").replace("-", "/")
+
+
+def project_label(transcript_path):
+    """Readable project name for a transcript path under ~/.claude/projects/."""
+    if "/projects/" in transcript_path:
+        dirname = transcript_path.split("/projects/")[1].split("/")[0]
+    else:
+        dirname = transcript_path
+    return _label_from_dirname(dirname)
+
+
+def project_label_for_path(repo_abs_path):
+    """The dashboard label a repo at this filesystem path would get."""
+    abs_path = os.path.abspath(os.path.expanduser(repo_abs_path))
+    return _label_from_dirname(abs_path.replace("/", "-"))
+
+
+# ----------------------------------------------------------------- changelog
+
+def _strip_md(s):
+    s = re.sub(r"\*\*([^*]+)\*\*", r"\1", s)
+    s = re.sub(r"`([^`]+)`", r"\1", s)
+    s = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", s)
+    return s.strip()
+
+
+def parse_changelog(path, limit):
+    """Return [{version, date, sections:{name:[items]}}] for the newest releases."""
+    releases = []
+    cur = None
+    cur_section = None
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return releases
+    for line in lines:
+        mv = VERSION_RE.match(line)
+        if mv:
+            if cur:
+                releases.append(cur)
+                if len(releases) >= limit:
+                    return releases
+            cur = {"version": mv.group(1), "date": (mv.group(2) or "").strip(), "sections": {}}
+            cur_section = None
+            continue
+        if cur is None:
+            continue
+        ms = SECTION_RE.match(line)
+        if ms:
+            cur_section = ms.group(1).strip()
+            cur["sections"].setdefault(cur_section, [])
+            continue
+        mb = BULLET_RE.match(line)
+        if mb:
+            sec = cur_section or "Notes"
+            cur["sections"].setdefault(sec, []).append(mb.group(1).strip())
+    if cur and len(releases) < limit:
+        releases.append(cur)
+    return releases
+
+
+# ----------------------------------------------------------------- git
+
+def git_summary(repo):
+    """Commits not yet released, bucketed by conventional-commit type.
+
+    The boundary is the most recent `chore(release):` commit — that matches how
+    releases are actually cut, so it stays correct even when git tags lag the
+    CHANGELOG. Falls back to the latest tag, then to the whole history.
+    """
+    def git(*a):
+        return subprocess.run(["git", "-C", repo, *a], capture_output=True,
+                              text=True, timeout=10)
+    try:
+        if git("rev-parse", "--is-inside-work-tree").returncode != 0:
+            return None
+        rel = git("log", "--grep=^chore(release)", "-n", "1", "--pretty=%H").stdout.strip()
+        if rel:
+            boundary, since = rel, "last release"
+        else:
+            tag = git("describe", "--tags", "--abbrev=0").stdout.strip()
+            boundary, since = tag, (tag or "(no releases)")
+        rng = f"{boundary}..HEAD" if boundary else "HEAD"
+        out = git("log", rng, "--no-merges", "--pretty=%s").stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+    subjects = [s for s in out.splitlines() if s]
+    buckets = {}
+    for s in subjects:
+        m = CC_RE.match(s)
+        buckets.setdefault(m.group(1) if m else "other", []).append(s)
+    return {"since": since, "count": len(subjects), "buckets": buckets}
+
+
+# ----------------------------------------------------------------- value snapshot
+
+def repo_value(repo_path, versions=5, source="registry"):
+    """Full value snapshot for one repo: releases (CHANGELOG) + unreleased (git)."""
+    repo = os.path.abspath(os.path.expanduser(repo_path))
+    name = os.path.basename(repo.rstrip("/")) or repo
+    releases = parse_changelog(os.path.join(repo, "CHANGELOG.md"), versions)
+    g = git_summary(repo)
+    unreleased = None
+    if g is not None:
+        unreleased = {"since": g["since"], "count": g["count"],
+                      "buckets": {k: len(v) for k, v in g["buckets"].items()}}
+    return {
+        "path": repo,
+        "name": name,
+        "label": project_label_for_path(repo),
+        "source": source,
+        "scanned": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        "releases": [
+            {"version": r["version"], "date": r["date"], "sections": r["sections"],
+             "items": sum(len(v) for v in r["sections"].values())}
+            for r in releases
+        ],
+        "unreleased": unreleased,
+    }
+
+
+# ----------------------------------------------------------------- store I/O
+
+def load_store():
+    try:
+        with open(STORE_PATH, encoding="utf-8") as f:
+            s = json.load(f)
+        if s.get("version") == STORE_VERSION and isinstance(s.get("repos"), dict):
+            return s
+    except (OSError, ValueError):
+        pass
+    return {"version": STORE_VERSION, "repos": {}}
+
+
+def save_store(store):
+    try:
+        os.makedirs(STORE_DIR, exist_ok=True)
+        with open(STORE_PATH, "w", encoding="utf-8") as f:
+            json.dump(store, f, indent=2)
+    except OSError as e:
+        print(f"warning: could not write value store ({STORE_PATH}): {e}", file=sys.stderr)
+
+
+def save_repo(entry):
+    """Upsert one repo (keyed by its path). A registry entry is never overwritten
+    by an auto entry."""
+    store = load_store()
+    path = entry["path"]
+    existing = store["repos"].get(path)
+    if existing and existing.get("source") == "registry" and entry.get("source") == "auto":
+        return store
+    store["repos"][path] = {k: v for k, v in entry.items() if k != "path"}
+    save_store(store)
+    return store
+
+
+def autodiscover(known_paths):
+    """Best-effort: transcript dirs whose `-`→`/` path is a git repo with a
+    CHANGELOG. Hyphenated path segments can't be recovered (the mangling is
+    lossy), so the registry remains the source of truth — this only adds the
+    repos it can prove exist on disk."""
+    import glob
+    found = []
+    for d in glob.glob(os.path.join(PROJECTS_DIR, "*")):
+        if not os.path.isdir(d):
+            continue
+        cand = "/" + os.path.basename(d).lstrip("-").replace("-", "/")
+        if cand in known_paths or cand in found:
+            continue
+        if os.path.isdir(os.path.join(cand, ".git")) and \
+           os.path.exists(os.path.join(cand, "CHANGELOG.md")):
+            found.append(cand)
+    return found
+
+
+def refresh_store():
+    """Re-scan every known repo (keeping its source) and add newly discoverable
+    git repos, then persist once. Returns the fresh store."""
+    store = load_store()
+    known = dict(store.get("repos", {}))
+    repos = {}
+    for path, e in known.items():
+        if os.path.isdir(path):
+            v = repo_value(path, source=e.get("source", "registry"))
+            repos[path] = {k: val for k, val in v.items() if k != "path"}
+        else:
+            repos[path] = e  # path gone — keep the last snapshot rather than drop it
+    for path in autodiscover(set(known)):
+        if path not in repos:
+            v = repo_value(path, source="auto")
+            repos[path] = {k: val for k, val in v.items() if k != "path"}
+    store["repos"] = repos
+    save_store(store)
+    return store

--- a/scripts/test_value.py
+++ b/scripts/test_value.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests for the value × cost pipeline (_shipped + token-dashboard value join).
+
+Run: python3 scripts/test_value.py
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import _shipped  # noqa: E402
+
+# token-dashboard.py has a hyphen → load it by path.
+_spec = importlib.util.spec_from_file_location(
+    "token_dashboard", os.path.join(HERE, "token-dashboard.py"))
+td = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(td)
+
+
+def git(repo, *args):
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t.t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", "-C", repo, *args],
+        capture_output=True, text=True, check=False)
+
+
+def commit(repo, subject):
+    with open(os.path.join(repo, "f.txt"), "a") as f:
+        f.write(subject + "\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", subject)
+
+
+def write(path, text):
+    with open(path, "w") as f:
+        f.write(text)
+
+
+class ChangelogTest(unittest.TestCase):
+    def test_parse_releases_sections_bullets(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "CHANGELOG.md")
+            write(p,
+                  "# Changelog\n\n"
+                  "## [1.1.0] — 2026-01-10\n### Added\n- one\n- two\n### Fixed\n- bug\n\n"
+                  "## [1.0.0] — 2026-01-05\n### Added\n- start\n")
+            rels = _shipped.parse_changelog(p, 5)
+            self.assertEqual([r["version"] for r in rels], ["1.1.0", "1.0.0"])
+            self.assertEqual(rels[0]["date"], "2026-01-10")
+            self.assertEqual(rels[0]["sections"]["Added"], ["one", "two"])
+            self.assertEqual(rels[0]["sections"]["Fixed"], ["bug"])
+
+
+class GitBoundaryTest(unittest.TestCase):
+    def test_tag_lag_does_not_double_count(self):
+        """CHANGELOG ahead of tags: a released version's commits must NOT appear
+        as unreleased — the chore(release) boundary owns the cutoff."""
+        with tempfile.TemporaryDirectory() as repo:
+            git(repo, "init", "-q", "-b", "main")
+            commit(repo, "feat: a")
+            commit(repo, "chore(release): 1.0.0")
+            git(repo, "tag", "v1.0.0")          # tagged release
+            commit(repo, "feat: b")
+            commit(repo, "chore(release): 1.1.0")  # released in CHANGELOG, NOT tagged
+            commit(repo, "docs: c")
+            g = _shipped.git_summary(repo)
+            self.assertEqual(g["since"], "last release")
+            self.assertEqual(g["count"], 1)          # only "docs: c"
+            self.assertEqual(g["buckets"], {"docs": ["docs: c"]})
+            self.assertNotIn("feat", g["buckets"])    # 1.1.0's feat is NOT unreleased
+
+    def test_tag_fallback_when_no_release_commit(self):
+        with tempfile.TemporaryDirectory() as repo:
+            git(repo, "init", "-q", "-b", "main")
+            commit(repo, "feat: a")
+            git(repo, "tag", "v0.1.0")
+            commit(repo, "feat: b")
+            g = _shipped.git_summary(repo)
+            self.assertEqual(g["since"], "v0.1.0")
+            self.assertEqual(g["count"], 1)
+            self.assertEqual(list(g["buckets"]), ["feat"])
+
+
+class StoreTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._orig = (_shipped.STORE_DIR, _shipped.STORE_PATH, _shipped.PROJECTS_DIR)
+        _shipped.STORE_DIR = self.tmp.name
+        _shipped.STORE_PATH = os.path.join(self.tmp.name, "value.json")
+        _shipped.PROJECTS_DIR = os.path.join(self.tmp.name, "projects")  # empty → no autodiscover
+
+    def tearDown(self):
+        _shipped.STORE_DIR, _shipped.STORE_PATH, _shipped.PROJECTS_DIR = self._orig
+        self.tmp.cleanup()
+
+    def test_roundtrip_and_registry_beats_auto(self):
+        reg = {"path": "/x/foo", "name": "foo", "label": "~/foo",
+               "source": "registry", "releases": [], "unreleased": None}
+        _shipped.save_repo(reg)
+        self.assertEqual(_shipped.load_store()["repos"]["/x/foo"]["source"], "registry")
+        # auto must NOT clobber a registry entry
+        _shipped.save_repo({**reg, "source": "auto"})
+        self.assertEqual(_shipped.load_store()["repos"]["/x/foo"]["source"], "registry")
+
+    def test_value_panel_windowed_cost(self):
+        store = {"version": 1, "repos": {"/x/foo": {
+            "name": "foo", "label": "~/foo", "source": "registry",
+            "releases": [
+                {"version": "1.1", "date": "2026-01-10", "items": 2,
+                 "sections": {"Added": ["a", "b"]}},
+                {"version": "1.0", "date": "2026-01-05", "items": 1,
+                 "sections": {"Added": ["x"]}},
+            ],
+            "unreleased": {"since": "last release", "count": 3, "buckets": {"feat": 3}},
+        }}}
+        _shipped.save_store(store)
+        data = {"by_project_day_cost": {"~/foo": {
+            "2026-01-04": 10.0, "2026-01-06": 20.0, "2026-01-08": 5.0,
+            "2026-01-11": 7.0, "2026-01-20": 3.0}}}
+        panel = td.value_panel(data)
+        repo = panel["repos"][0]
+        self.assertTrue(repo["has_cost"])
+        costs = {r["version"]: r["cost"] for r in repo["releases"]}
+        self.assertEqual(costs["1.1"], 25.0)   # (01-05, 01-10]: 20 + 5
+        self.assertEqual(costs["1.0"], 10.0)    # (-inf, 01-05]: 10
+        self.assertEqual(repo["unreleased"]["cost"], 10.0)  # (01-10, ...]: 7 + 3
+        self.assertEqual(repo["releases"][0]["top"], ["a", "b"])
+
+
+class LabelTest(unittest.TestCase):
+    def test_path_label_matches_dashboard(self):
+        """The label the CLI registers must equal the label the dashboard derives
+        from the same repo's transcript dir — otherwise cost never joins value."""
+        repo = os.path.join(_shipped.HOME, "personal-github", "100xprism")
+        transcript = os.path.join(
+            _shipped.PROJECTS_DIR,
+            repo.replace("/", "-"), "session.jsonl")
+        self.assertEqual(_shipped.project_label_for_path(repo),
+                         td.project_label(transcript))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/token-dashboard.py
+++ b/scripts/token-dashboard.py
@@ -272,6 +272,9 @@ def build(verbose=True):
         lbl: {day: round(cost(dd), 4) for day, dd in days.items()}
         for lbl, days in by_project_day.items()
     }
+    # Re-scan the value store once per rebuild (every 5 min / on demand), not per
+    # /api/value request — git subprocesses stay off the request path.
+    value_store = _shipped.refresh_store().get("repos", {})
 
     # Composition estimate: chars ÷ 4 ≈ tokens. Labelled an estimate in the UI.
     comp_tokens = {k: comp_chars.get(k, 0) // 4 for k in COMP_CATS}
@@ -302,6 +305,7 @@ def build(verbose=True):
             key=lambda r: -(r[1]["input"] + r[1]["cache_read"] + r[1]["cache_write"]),
         ),
         "by_project_day_cost": by_project_day_cost,
+        "value_store": value_store,
     }
 
 
@@ -369,10 +373,14 @@ def value_panel(data):
     the estimated cost is that project's spend over (prev release date, this
     release date]. Attribution is by date window — an estimate, like composition.
     """
-    store = _shipped.refresh_store()
+    # Use the store cached by build() (refreshed each rebuild). Standalone callers
+    # that didn't go through build() fall back to a plain load — no rescan here.
+    store_repos = data.get("value_store")
+    if store_repos is None:
+        store_repos = _shipped.load_store().get("repos", {})
     bpd = data.get("by_project_day_cost", {})
     repos = []
-    for path, e in store.get("repos", {}).items():
+    for path, e in store_repos.items():
         daycost = bpd.get(e.get("label"), {})
         releases = e.get("releases", [])
         rows = []
@@ -474,7 +482,7 @@ function valueHTML(){
   }
   h+='</table>';
  }
- h+=`<p class=muted style=margin-top:8px>Cost is this project's token spend over each release's date window (previous release → this release) — directional, not billed-per-feature. Run <code>100x-value</code> in a repo to add it here.</p>`;
+ h+=`<p class=muted style=margin-top:8px>Cost is this project's token spend over each release's date window (previous release → this release) — directional, not billed-per-feature. Repos come from the registry — run <code>100x-value</code> in a repo to add it here; auto-discovery is best-effort and skips paths it can't resolve.</p>`;
  return h;
 }
 function render(d){
@@ -539,8 +547,9 @@ def _rebuild():
 
 
 def _client_data(data):
-    """Token data for the browser, minus the heavy internal join map."""
-    return {k: v for k, v in data.items() if k != "by_project_day_cost"}
+    """Token data for the browser, minus the heavy server-only fields."""
+    drop = {"by_project_day_cost", "value_store"}
+    return {k: v for k, v in data.items() if k not in drop}
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/scripts/token-dashboard.py
+++ b/scripts/token-dashboard.py
@@ -36,15 +36,21 @@ import json
 import os
 import socket
 import sys
+import threading
+import time
 import webbrowser
 from collections import defaultdict
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _shipped  # noqa: E402 — shared value/store helper (one source of truth)
+
 HOME = os.path.expanduser("~")
 PROJECTS_DIR = os.path.join(HOME, ".claude", "projects")
 CACHE_FILE = os.path.join(HOME, ".claude", ".token-dashboard-cache.json")
 CACHE_VERSION = 2
+REFRESH_SECONDS = 300  # auto-rebuild cadence so a long-lived tab never goes stale
 
 # $ per 1M tokens — rough Opus-tier list prices; edit to match your plan/model.
 RATES = {"input": 15.0, "output": 75.0, "cache_read": 1.5, "cache_write": 18.75}
@@ -190,10 +196,9 @@ def save_cache(files):
         print(f"warning: could not write cache: {e}", file=sys.stderr)
 
 
-def project_label(path):
-    """Turn a transcript path into a readable project name."""
-    seg = path.split("/projects/")[1].split("/")[0] if "/projects/" in path else path
-    return seg.replace("-Users-rajit-", "~/").replace("-", "/")
+# project_label lives in _shipped so the dashboard and the value store derive the
+# exact same join key from a path.
+project_label = _shipped.project_label
 
 
 def build(verbose=True):
@@ -229,6 +234,7 @@ def build(verbose=True):
     totals = _empty()
     by_project = defaultdict(_empty)
     by_day = defaultdict(_empty)
+    by_project_day = defaultdict(lambda: defaultdict(_empty))
     by_model = defaultdict(_empty)
     comp_chars = defaultdict(int)
     sessions = 0
@@ -237,10 +243,12 @@ def build(verbose=True):
     for s in new_cache.values():
         t = s["totals"]
         _add(totals, t["input"], t["output"], t["cache_read"], t["cache_write"])
-        bp = by_project[s.get("project", "?")]
+        proj = s.get("project", "?")
+        bp = by_project[proj]
         _add(bp, t["input"], t["output"], t["cache_read"], t["cache_write"])
         for day, d in s.get("by_day", {}).items():
             _add(by_day[day], d["input"], d["output"], d["cache_read"], d["cache_write"])
+            _add(by_project_day[proj][day], d["input"], d["output"], d["cache_read"], d["cache_write"])
         for mdl, d in s.get("by_model", {}).items():
             _add(by_model[mdl], d["input"], d["output"], d["cache_read"], d["cache_write"])
         for cat, n in s.get("comp", {}).items():
@@ -258,6 +266,12 @@ def build(verbose=True):
 
     def cost(d):
         return sum(d[k] / 1_000_000 * RATES[k] for k in RATES)
+
+    # cost per (project label × day) — server-side input to the value↔cost join
+    by_project_day_cost = {
+        lbl: {day: round(cost(dd), 4) for day, dd in days.items()}
+        for lbl, days in by_project_day.items()
+    }
 
     # Composition estimate: chars ÷ 4 ≈ tokens. Labelled an estimate in the UI.
     comp_tokens = {k: comp_chars.get(k, 0) // 4 for k in COMP_CATS}
@@ -287,6 +301,7 @@ def build(verbose=True):
             ([k, v] for k, v in by_model.items()),
             key=lambda r: -(r[1]["input"] + r[1]["cache_read"] + r[1]["cache_write"]),
         ),
+        "by_project_day_cost": by_project_day_cost,
     }
 
 
@@ -319,6 +334,68 @@ def print_summary(data):
         tot = v["input"] + v["cache_read"] + v["cache_write"]
         print(f"    {fmt(tot):>8} in / {fmt(v['output']):>6} out  ${c:>8,.0f}  {name}")
     print()
+
+
+# ---------------------------------------------------------------- value × cost
+
+def _window_cost(daycost, start, end):
+    """Sum a project's daily cost over the window (start, end].
+
+    start=None → open at the beginning; end=None → open through today. Dates are
+    "YYYY-MM-DD" strings, which sort lexicographically.
+    """
+    total = 0.0
+    for day, c in daycost.items():
+        if start and day <= start:
+            continue
+        if end and day > end:
+            continue
+        total += c
+    return round(total, 2)
+
+
+def _top_items(release, n=3):
+    out = []
+    for items in release.get("sections", {}).values():
+        for it in items:
+            out.append(_shipped._strip_md(it))
+            if len(out) >= n:
+                return out
+    return out
+
+
+def value_panel(data):
+    """Join the central value store to per-project token cost: for each release,
+    the estimated cost is that project's spend over (prev release date, this
+    release date]. Attribution is by date window — an estimate, like composition.
+    """
+    store = _shipped.refresh_store()
+    bpd = data.get("by_project_day_cost", {})
+    repos = []
+    for path, e in store.get("repos", {}).items():
+        daycost = bpd.get(e.get("label"), {})
+        releases = e.get("releases", [])
+        rows = []
+        for i, r in enumerate(releases):
+            d_this = r.get("date") or None
+            d_prev = releases[i + 1].get("date") or None if i + 1 < len(releases) else None
+            rows.append({
+                "version": r.get("version"), "date": r.get("date"),
+                "items": r.get("items"), "top": _top_items(r),
+                "cost": _window_cost(daycost, d_prev, d_this) if d_this else None,
+            })
+        newest_date = releases[0].get("date") or None if releases else None
+        un = e.get("unreleased")
+        unreleased = None
+        if un:
+            unreleased = {**un, "cost": _window_cost(daycost, newest_date, None)}
+        repos.append({
+            "name": e.get("name"), "label": e.get("label"),
+            "source": e.get("source"), "scanned": e.get("scanned"),
+            "has_cost": bool(daycost), "releases": rows, "unreleased": unreleased,
+        })
+    repos.sort(key=lambda r: (r.get("source") != "registry", r.get("name") or ""))
+    return {"repos": repos, "store_path": _shipped.STORE_PATH}
 
 
 # ---------------------------------------------------------------- web UI
@@ -372,13 +449,37 @@ function legend(){return `<div class=legend>
  <span><i class=dot style=background:var(--cw)></i>cache write</span>
  <span><i class=dot style=background:var(--in)></i>input</span>
  <span><i class=dot style=background:var(--out)></i>output</span></div>`;}
+let VALUE=null;
+async function loadValue(){try{VALUE=await (await fetch('/api/value')).json();}catch(e){VALUE=null;}}
 async function load(){
- const d=await (await fetch('/api/data')).json(); render(d);}
+ const [d]=await Promise.all([ (await fetch('/api/data')).json(), loadValue() ]); render(d);}
 async function refresh(){document.getElementById('app').innerHTML='<p class=muted>Rescanning…</p>';
- const d=await (await fetch('/api/refresh')).json(); render(d);}
+ const [d]=await Promise.all([ (await fetch('/api/refresh')).json(), loadValue() ]); render(d);}
+function money(c){return c==null?'<span class=muted>—</span>':'$'+(+c).toLocaleString(undefined,{maximumFractionDigits:0});}
+function valueHTML(){
+ if(!VALUE||!VALUE.repos||!VALUE.repos.length) return '';
+ let h=`<h2>Value — cost vs. what shipped <span class=muted style="text-transform:none;font-weight:400">— estimate, cost attributed by date window</span></h2>`;
+ for(const r of VALUE.repos){
+  h+=`<h3 style="margin:18px 0 6px;font-size:13px">${esc(r.name)} <span class=muted style="font-weight:400">· ${esc(r.label||'')} · ${r.source}</span></h3>`;
+  if(!r.has_cost) h+=`<p class=muted style=margin:0_0_6px>No token cost matched this repo's label yet — value shown without cost.</p>`;
+  h+=`<table><tr><th>release</th><th>date</th><th>what shipped</th><th>items</th><th>est $</th></tr>`;
+  if(r.unreleased&&r.unreleased.count)
+   h+=`<tr><td><em>unreleased</em></td><td class=muted>since ${esc(r.unreleased.since||'')}</td>
+     <td>${Object.entries(r.unreleased.buckets||{}).map(([k,n])=>esc(k)+' '+n).join(', ')||'—'}</td>
+     <td>${r.unreleased.count}</td><td>${money(r.unreleased.cost)}</td></tr>`;
+  for(const rel of r.releases){
+   h+=`<tr><td>v${esc(rel.version)}</td><td class=muted>${esc(rel.date||'')}</td>
+     <td>${(rel.top||[]).map(esc).join('<br>')||'—'}</td>
+     <td>${rel.items==null?'—':rel.items}</td><td>${money(rel.cost)}</td></tr>`;
+  }
+  h+='</table>';
+ }
+ h+=`<p class=muted style=margin-top:8px>Cost is this project's token spend over each release's date window (previous release → this release) — directional, not billed-per-feature. Run <code>100x-value</code> in a repo to add it here.</p>`;
+ return h;
+}
 function render(d){
  document.getElementById('meta').textContent=
-  `${d.transcripts} transcripts · ${d.sessions} sessions · generated ${d.generated}`;
+  `${d.transcripts} transcripts · ${d.sessions} sessions · updated ${d.generated}`;
  const t=d.totals, max=Math.max(...d.bloat.window?[]:[1]);
  const card=(lbl,val,note,col)=>`<div class=card><div class=lbl>${col?`<i class=dot style=background:${col}></i>`:''}${lbl}</div>
    <div class=val>${val}</div><div class=note>${note||''}</div></div>`;
@@ -391,6 +492,7 @@ function render(d){
    ${card('input',fmt(t.input),'new uncached text','var(--in)')}
    ${card('est. cost','$'+d.total_cost.toLocaleString(),'rough, list rates (editable)')}
   </div>`;
+ h+=valueHTML();
  h+=`<h2>Startup bloat — fixed context re-sent every turn</h2>
    <div class=meter><b style="width:${mw}%;background:${mw>30?'var(--cw)':'var(--cr)'}"></b>
    <em>median ${fmt(d.bloat.median)} of 200K window (${(d.bloat.median/W*100).toFixed(1)}%)</em></div>
@@ -423,7 +525,22 @@ function render(d){
  document.getElementById('app').innerHTML=h;
 }
 load();
+setInterval(load, 300000);  // auto-refresh every 5 min so the tab never goes stale
 </script></body></html>"""
+
+
+_build_lock = threading.Lock()
+
+
+def _rebuild():
+    with _build_lock:
+        Handler.data = build(verbose=False)
+    return Handler.data
+
+
+def _client_data(data):
+    """Token data for the browser, minus the heavy internal join map."""
+    return {k: v for k, v in data.items() if k != "by_project_day_cost"}
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -442,12 +559,15 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.startswith("/api/refresh"):
-            Handler.data = build(verbose=False)
-            self._send(json.dumps(Handler.data))
+            self._send(json.dumps(_client_data(_rebuild())))
         elif self.path.startswith("/api/data"):
             if Handler.data is None:
-                Handler.data = build(verbose=False)
-            self._send(json.dumps(Handler.data))
+                _rebuild()
+            self._send(json.dumps(_client_data(Handler.data)))
+        elif self.path.startswith("/api/value"):
+            if Handler.data is None:
+                _rebuild()
+            self._send(json.dumps(value_panel(Handler.data)))
         else:
             self._send(PAGE, "text/html; charset=utf-8")
 
@@ -528,6 +648,17 @@ def main():
                 pass
         return
     print(f"\nToken dashboard → {url}  (Ctrl-C to stop) — all sessions & repos on this machine")
+
+    def _auto_refresh():
+        while True:
+            time.sleep(REFRESH_SECONDS)
+            try:
+                _rebuild()
+            except Exception:
+                pass
+
+    threading.Thread(target=_auto_refresh, daemon=True).start()
+
     if not args.no_open:
         try:
             webbrowser.open(url)

--- a/scripts/value-report.py
+++ b/scripts/value-report.py
@@ -2,10 +2,13 @@
 """
 value-report.py — what SHIPPED, to read alongside token cost.
 
-The token dashboard measures *cost*. This measures *delivered value* — the part
-no token tool can know, because it isn't in the transcripts. It summarizes what a
-repo shipped from its CHANGELOG.md (Keep a Changelog format) and, when available,
-recent git history bucketed by conventional-commit type.
+The token dashboard measures *cost*. This measures *delivered value* — what a
+repo shipped, from its CHANGELOG.md plus the unreleased commits on top of the
+last release.
+
+Running it also REGISTERS this repo in the central store (~/.100xprism/value.json)
+so the `100x-tokens` dashboard can show this value side by side with what it
+cost in tokens — one URL, cost next to value.
 
 Offline, no third-party dependencies.
 
@@ -13,118 +16,57 @@ Usage:
     python3 scripts/value-report.py                 # current repo (cwd)
     python3 scripts/value-report.py /path/to/repo   # a specific repo
     python3 scripts/value-report.py --versions 8    # how many releases to show
+    python3 scripts/value-report.py --no-register   # print only, don't touch the store
 """
 import argparse
 import os
-import re
-import subprocess
 import sys
 
-VERSION_RE = re.compile(r"^##\s*\[([^\]]+)\]\s*(?:[—-]\s*(.+))?$")
-SECTION_RE = re.compile(r"^###\s+(.+)$")
-BULLET_RE = re.compile(r"^[-*]\s+(.+)$")
-CC_RE = re.compile(r"^([a-z]+)(?:\([^)]*\))?!?:")
-
-
-def parse_changelog(path, limit):
-    """Return [{version, date, sections:{name:[items]}}] for the newest releases."""
-    releases = []
-    cur = None
-    cur_section = None
-    try:
-        lines = open(path, encoding="utf-8", errors="ignore").read().splitlines()
-    except OSError:
-        return releases
-    for line in lines:
-        mv = VERSION_RE.match(line)
-        if mv:
-            if cur:
-                releases.append(cur)
-                if len(releases) >= limit:
-                    return releases
-            cur = {"version": mv.group(1), "date": (mv.group(2) or "").strip(), "sections": {}}
-            cur_section = None
-            continue
-        if cur is None:
-            continue
-        ms = SECTION_RE.match(line)
-        if ms:
-            cur_section = ms.group(1).strip()
-            cur["sections"].setdefault(cur_section, [])
-            continue
-        mb = BULLET_RE.match(line)
-        if mb:
-            sec = cur_section or "Notes"
-            cur["sections"].setdefault(sec, []).append(mb.group(1).strip())
-    if cur and len(releases) < limit:
-        releases.append(cur)
-    return releases
-
-
-def _strip_md(s):
-    s = re.sub(r"\*\*([^*]+)\*\*", r"\1", s)
-    s = re.sub(r"`([^`]+)`", r"\1", s)
-    s = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", s)
-    return s.strip()
-
-
-def git_summary(repo):
-    """Commits since the latest tag, bucketed by conventional-commit type."""
-    def git(*a):
-        return subprocess.run(["git", "-C", repo, *a], capture_output=True,
-                              text=True, timeout=10)
-    try:
-        if git("rev-parse", "--is-inside-work-tree").returncode != 0:
-            return None
-        tag = git("describe", "--tags", "--abbrev=0").stdout.strip()
-        rng = f"{tag}..HEAD" if tag else "HEAD"
-        out = git("log", rng, "--no-merges", "--pretty=%s").stdout.strip()
-    except (OSError, subprocess.SubprocessError):
-        return None
-    subjects = [s for s in out.splitlines() if s]
-    buckets = {}
-    for s in subjects:
-        m = CC_RE.match(s)
-        buckets.setdefault(m.group(1) if m else "other", []).append(s)
-    return {"since_tag": tag, "count": len(subjects), "buckets": buckets}
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _shipped  # noqa: E402
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("repo", nargs="?", default=os.getcwd())
     ap.add_argument("--versions", type=int, default=5)
+    ap.add_argument("--no-register", action="store_true",
+                    help="print only; do not write this repo to the central store")
     args = ap.parse_args()
 
-    repo = os.path.abspath(os.path.expanduser(args.repo))
-    name = os.path.basename(repo.rstrip("/"))
+    v = _shipped.repo_value(args.repo, versions=args.versions)
+    repo, name = v["path"], v["name"]
     print(f"\nValue report — {name}  ({repo})")
 
-    changelog = os.path.join(repo, "CHANGELOG.md")
-    releases = parse_changelog(changelog, args.versions)
-    if releases:
-        print(f"\nShipped (last {len(releases)} release(s), from CHANGELOG.md):")
-        for r in releases:
+    if v["releases"]:
+        print(f"\nShipped (last {len(v['releases'])} release(s), from CHANGELOG.md):")
+        for r in v["releases"]:
             head = f"  v{r['version']}" + (f"  ·  {r['date']}" if r["date"] else "")
-            counts = "  ".join(f"{n} {s.lower()}" for s, n in
-                               ((s, len(items)) for s, items in r["sections"].items()) if n)
+            counts = "  ".join(f"{len(items)} {sec.lower()}"
+                               for sec, items in r["sections"].items() if items)
             print(f"\n{head}" + (f"   [{counts}]" if counts else ""))
             for sec, items in r["sections"].items():
                 for it in items[:3]:
-                    line = _strip_md(it)
+                    line = _shipped._strip_md(it)
                     print(f"     • {line[:96] + ('…' if len(line) > 96 else '')}")
                 if len(items) > 3:
                     print(f"     • …+{len(items) - 3} more in {sec}")
     else:
         print("\n  No CHANGELOG.md found (or empty).")
 
-    g = git_summary(repo)
-    if g and g["count"]:
-        since = f"since {g['since_tag']}" if g["since_tag"] else "(no tags)"
-        print(f"\nUnreleased work {since}: {g['count']} commit(s)")
-        for typ, subs in sorted(g["buckets"].items(), key=lambda kv: -len(kv[1])):
-            print(f"  {len(subs):>3}  {typ}")
-    elif g is not None:
-        print("\nUnreleased work: none since the latest tag.")
+    un = v["unreleased"]
+    if un is None:
+        pass  # not a git repo
+    elif un["count"]:
+        print(f"\nUnreleased work since {un['since']}: {un['count']} commit(s)")
+        for typ, n in sorted(un["buckets"].items(), key=lambda kv: -kv[1]):
+            print(f"  {n:>3}  {typ}")
+    else:
+        print(f"\nUnreleased work: none since {un['since']}.")
+
+    if not args.no_register:
+        _shipped.save_repo(v)
+        print(f"\n  registered → {_shipped.STORE_PATH} (shows in the 100x-tokens dashboard)")
     print()
 
 


### PR DESCRIPTION
## Summary
- `100x-value` was a CHANGELOG/git summarizer that read **zero** token data — the README's "what shipped *for that spend*" was only half-built. This wires value to cost so they sit in one screen.
- New **"Value — cost vs. what shipped"** panel renders in the existing `100x-tokens` dashboard URL: each release's *estimated* token cost (attributed by date window) next to what it delivered.
- Fixes a tag double-count bug and adds 5-minute auto-refresh so a long-lived tab never goes stale.

## Changes
- **`scripts/_shipped.py`** (new) — one parser shared by the CLI and dashboard (changelog, git, labels, central store) so they never drift.
- **`scripts/value-report.py`** — slimmed to a CLI over `_shipped`; each run registers the repo in a central store at `~/.100xprism/value.json`.
- **`scripts/token-dashboard.py`** — new `by_project_day` cost aggregate, `/api/value` route, the value panel, and a server rebuild thread + client poll (5 min).
- **Tag double-count fix** — the "unreleased" boundary is now the last `chore(release):` commit, so versions already in the CHANGELOG stop reappearing as unreleased.
- **`scripts/test_value.py`** (new) — 6 unittest cases incl. the tag-lag regression and the date-window cost join.
- **`README.md`** + **`docs/token-optimization.md`** updated; design spec under `docs/superpowers/specs/`.

## Test plan
- [x] JS suite green (`node --test`): 62/62
- [x] Python suite green (`scripts/test_value.py`): 6/6, incl. tag-lag regression + windowed-cost join
- [x] `npm run check` (meta-check + adapter emit) clean; no secrets in diff
- [x] Live server: `/api/value` returns per-release costs; `/api/data` omits the heavy internal map; page renders the panel
- [ ] Reviewer: open `100x-tokens`, run `100x-value` in a repo, confirm it appears with cost next to each release

## Related issues
None.