### PR TITLE
fix: resolve hidden/hyphenated directories + mark removed dirs

### DIFF
--- a/scripts/_value.py
+++ b/scripts/_value.py
@@ -27,6 +27,12 @@ STORE_VERSION = 2
 _HOME_DASH = HOME.replace("/", "-") + "-"  # e.g. "-Users-rajit-"
 
 
+def mangle_path(abs_path):
+    """The ~/.claude/projects transcript-dir name for a path: every
+    non-alphanumeric character becomes '-' (Claude Code's exact rule)."""
+    return re.sub(r"[^a-zA-Z0-9]", "-", abs_path)
+
+
 # ----------------------------------------------------------------- labels
 
 def _label_from_dirname(dirname):
@@ -219,7 +225,12 @@ def save_store(store):
 
 AGENT_MARKERS = ("CLAUDE.md", "AGENTS.md", "GEMINI.md", ".cursorrules",
                  ".windsurfrules", ".clinerules", ".github/copilot-instructions.md")
-_DISCOVER_SKIP = _SKIP_DIRS | {"Library", "Movies", "Music", "Pictures", "Applications"}
+_DISCOVER_SKIP = _SKIP_DIRS | {
+    "Library", "Movies", "Music", "Pictures", "Applications", "go",
+    ".git", ".cache", ".npm", ".cargo", ".rustup", ".gradle", ".m2",
+    ".nvm", ".pyenv", ".rbenv", ".vscode", ".vscode-server", ".Trash",
+    ".cursor", ".docker", ".ollama", ".terraform.d",
+}
 
 
 def discover_project_dirs(root=None, max_depth=6):
@@ -240,20 +251,50 @@ def discover_project_dirs(root=None, max_depth=6):
     return found
 
 
-def cached_discover(root=None, ttl=1800):
-    """Discovery cached in the value store (re-walked only when older than ttl
-    seconds). Returns {real_abs_dir: label}."""
+def scan_home(root=None, max_depth=6):
+    """One $HOME walk → (markers {real_dir: label}, index {mangled: real_dir}).
+
+    Unlike discover_project_dirs, does NOT blanket-prune dotdirs — it uses the
+    explicit _DISCOVER_SKIP denylist instead, so hidden project roots like
+    .claude-mem are indexed and appear in the reverse-mangle index."""
+    root = os.path.abspath(os.path.expanduser(root or HOME))
+    base = root.rstrip("/").count("/")
+    markers, index = {}, {}
+    for dp, dirs, files in os.walk(root):
+        if dp.rstrip("/").count("/") - base >= max_depth:
+            dirs[:] = []
+        dirs[:] = [d for d in dirs if d not in _DISCOVER_SKIP]
+        index[mangle_path(dp)] = dp
+        fs = set(files)
+        if any((m in fs) or (os.sep in m and os.path.exists(os.path.join(dp, m)))
+               for m in AGENT_MARKERS):
+            markers[dp] = project_label_for_path(dp)
+    return markers, index
+
+
+def cached_scan(root=None, ttl=1800):
+    """Discovery cached in the value store. Returns (markers, index).
+    markers = {real_abs_dir: label}
+    index   = {mangled_dirname: real_abs_dir}  — the reverse-mangle lookup table."""
     import time
     store = load_store()
     now = time.time()
-    if store.get("discovered_at") and (now - store["discovered_at"]) < ttl \
-            and isinstance(store.get("discovered"), dict):
-        return store["discovered"]
-    disc = discover_project_dirs(root)
-    store["discovered"] = disc
+    if (store.get("discovered_at") and (now - store["discovered_at"]) < ttl
+            and isinstance(store.get("discovered"), dict)
+            and isinstance(store.get("dir_index"), dict)):
+        return store["discovered"], store["dir_index"]
+    markers, index = scan_home(root)
+    store["discovered"] = markers
+    store["dir_index"] = index
     store["discovered_at"] = now
     save_store(store)
-    return disc
+    return markers, index
+
+
+def cached_discover(root=None, ttl=1800):
+    """Discovery cached in the value store (re-walked only when older than ttl
+    seconds). Returns {real_abs_dir: label}. Delegates to cached_scan."""
+    return cached_scan(root, ttl)[0]
 
 
 def cached_dir_value(real_dir, label, tool, start, end):

--- a/scripts/test_value.py
+++ b/scripts/test_value.py
@@ -196,6 +196,61 @@ class DirectoriesShapeTest(unittest.TestCase):
         self.assertIsNone(dirs[0]["cost"])
 
 
+class ScanHomeTest(unittest.TestCase):
+    def test_mangle_path_non_alnum_to_dash(self):
+        """mangle_path replaces every non-alphanumeric char with '-'."""
+        self.assertEqual(_value.mangle_path("/Users/rajit/100x-dev"),
+                         "-Users-rajit-100x-dev")
+        self.assertEqual(_value.mangle_path("/Users/rajit/.claude-mem/observer"),
+                         "-Users-rajit--claude-mem-observer")
+
+    def test_scan_home_indexes_hidden_and_hyphenated(self):
+        """scan_home index contains mangled keys for hidden + hyphenated dirs."""
+        with tempfile.TemporaryDirectory() as root:
+            # hyphenated dir
+            hyph = os.path.join(root, "100x-dev")
+            os.makedirs(hyph)
+            # hidden dir (not in _DISCOVER_SKIP)
+            hidden = os.path.join(root, ".my-proj")
+            os.makedirs(hidden)
+            write(os.path.join(hidden, "CLAUDE.md"), "# hidden-proj")
+            _, index = _value.scan_home(root)
+            # Both dirs must be in the index
+            self.assertIn(_value.mangle_path(hyph), index)
+            self.assertEqual(index[_value.mangle_path(hyph)], hyph)
+            self.assertIn(_value.mangle_path(hidden), index)
+            self.assertEqual(index[_value.mangle_path(hidden)], hidden)
+
+    def test_scan_home_markers_still_finds_claude_md(self):
+        """scan_home markers finds dirs with CLAUDE.md (no regression on discovery)."""
+        with tempfile.TemporaryDirectory() as root:
+            proj = os.path.join(root, "myproj")
+            os.makedirs(proj)
+            write(os.path.join(proj, "CLAUDE.md"), "# myproj")
+            markers, _ = _value.scan_home(root)
+            self.assertIn(proj, markers)
+
+    def test_resolution_via_index_beats_heuristic(self):
+        """assemble_directories resolves a mangled name via dir_index even when
+        resolve_real_dir would fail (hidden dir the heuristic can't un-mangle)."""
+        with tempfile.TemporaryDirectory() as root:
+            hidden_proj = os.path.join(root, ".claude-mem", "my-proj")
+            os.makedirs(hidden_proj)
+            label = _value.project_label_for_path(hidden_proj)
+            mangled = _value.mangle_path(hidden_proj)
+            dir_index = {mangled: hidden_proj}
+            rows = td.assemble_directories(
+                {mangled: label},
+                {label: {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0}},
+                {},
+                {label: (None, None)},
+                {label: "claude-code"},
+                dir_index=dir_index,
+            )
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["dir"], hidden_proj)
+
+
 class DiscoverTest(unittest.TestCase):
     def _make_tree(self, root):
         """Helper: create a temp tree with specific layout."""

--- a/scripts/token-dashboard.py
+++ b/scripts/token-dashboard.py
@@ -288,14 +288,15 @@ def build(verbose=True):
         if days:
             lo, hi = window_by_label.get(label, (days[0], days[-1]))
             window_by_label[label] = (min(lo, days[0]), max(hi, days[-1]))
-    discovered = _value.cached_discover()            # {real_dir: label}
+    discovered, dir_index = _value.cached_scan()     # markers + reverse-mangle index
     realdir_by_label = {}
     for real_dir, label in discovered.items():
         realdir_by_label.setdefault(label, real_dir)
     directories = assemble_directories(
         mangled_by_label, tokens_by_label, by_project_day_cost,
         window_by_label, tool_by_label,
-        discovered=discovered, realdir_by_label=realdir_by_label)
+        discovered=discovered, realdir_by_label=realdir_by_label,
+        dir_index=dir_index)
 
     # Composition estimate: chars ÷ 4 ≈ tokens. Labelled an estimate in the UI.
     comp_tokens = {k: comp_chars.get(k, 0) // 4 for k in COMP_CATS}
@@ -365,7 +366,7 @@ def print_summary(data):
 
 def assemble_directories(mangled_by_label, tokens_by_label, by_project_day_cost,
                          window_by_label, tool_by_label,
-                         discovered=None, realdir_by_label=None):
+                         discovered=None, realdir_by_label=None, dir_index=None):
     """Build the unified per-directory rows (cost + tool-agnostic value).
 
     mangled_by_label: {mangled_dirname: label} — key is the raw Claude projects dir name,
@@ -391,12 +392,10 @@ def assemble_directories(mangled_by_label, tokens_by_label, by_project_day_cost,
 
     rows = []
     for label in all_labels:
-        # Resolve real dir: discovery wins (authoritative), fallback to mangled resolve
-        real = realdir_by_label.get(label)
-        if real is None:
-            mangled = label_to_mangled.get(label)
-            if mangled:
-                real = _value.resolve_real_dir(mangled)
+        mangled = label_to_mangled.get(label)
+        real = realdir_by_label.get(label) \
+               or (dir_index.get(mangled) if (dir_index and mangled) else None) \
+               or (_value.resolve_real_dir(mangled) if mangled else None)
         start, end = window_by_label.get(label, (None, None))
         daycost = by_project_day_cost.get(label, {})
         _c = round(sum(daycost.values()), 2) if daycost else 0.0

--- a/scripts/token-dashboard.py
+++ b/scripts/token-dashboard.py
@@ -551,12 +551,16 @@ function dirsTable(dirs){
    </ul></details>`;
  h+=`<table><tr><th>directory</th><th>tool</th><th>est $</th><th>value (shipped)</th><th>AI note</th></tr>`;
  for(const d of dirs){
-  const v=d.value||{}; const shipped = v.kind==='git'
-    ? `${v.commits||0} commits${v.prs?'·'+v.prs+' PRs':''}`
-    : v.kind==='fs' ? `${v.fs_files} files` : '—';
-  h+=`<tr><td>${esc(d.label)}</td><td>${toolBadge(d.tool)}</td>`+
+  const v=d.value||{}; const removed=!d.dir;
+  const shipped = removed ? '<span class=muted>(removed)</span>'
+    : v.kind==='git' ? esc(`${v.commits||0} commits${v.prs?'·'+v.prs+' PRs':''}`)
+    : v.kind==='fs' ? esc(`${v.fs_files} files`) : '—';
+  const lbl = removed
+    ? `<span class=muted title="directory no longer on disk — value can't be computed">${esc(d.label)}</span>`
+    : esc(d.label);
+  h+=`<tr><td>${lbl}</td><td>${toolBadge(d.tool)}</td>`+
      `<td class=money>${d.cost==null?'<span class=muted>—</span>':'$'+Math.round(d.cost).toLocaleString()}</td>`+
-     `<td style="color:var(--value)">${esc(shipped)}</td>`+
+     `<td style="color:var(--value)">${shipped}</td>`+
      `<td class=muted>${v.summary?esc(v.summary):'<span class=muted>—</span>'}</td></tr>`;
  }
  return h+'</table>';


### PR DESCRIPTION
## Summary

Closes the directory-resolution gap in the token + value dashboard (follow-up to v2.4.0).

### What it does
- **Exact reverse-mangle index** — builds a `{mangled-name → real-path}` index from one `$HOME` walk using Claude Code's verified dir-naming rule (`re.sub(r"[^a-zA-Z0-9]", "-", path)`), so transcript directory names resolve deterministically — including **hidden roots** (`.claude-mem`) and **hyphenated names** (`100x-dev`) that the old heuristic missed.
- **Shared walk** — `scan_home()` produces both the marker-file discovery map and the index in a single cached `$HOME` traversal (TTL-cached, off the request path); pruning is now an explicit heavy-dir denylist instead of a blanket dotdir skip.
- **"(removed)" marker** — directories whose path no longer exists on disk (renamed repos, cleaned-up agent worktrees, temp dirs) now render as **(removed)** with a dimmed label, instead of a bare `—`, so it is clear the directory is gone rather than the value being broken.

### Result (verified in-browser)
37 directories, **22 resolved to real paths** (was 21 — the rest are genuinely deleted/ephemeral), 15 clearly marked **(removed)**, 0 console errors. Every directory that still exists on disk now resolves and shows git/fs value.

### Tests & review
- 25 Python + 62 Node green; reviewed (spec ✅, no blockers).
- Zero third-party deps, fully offline, serve path never blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
